### PR TITLE
Coll.distinct method removed

### DIFF
--- a/core/shared/src/main/scala/sigma/data/CGroupElement.scala
+++ b/core/shared/src/main/scala/sigma/data/CGroupElement.scala
@@ -11,10 +11,15 @@ import sigma.{BigInt, Coll, Colls, GroupElement, UnsignedBigInt}
   */
 case class CGroupElement(override val wrappedValue: Ecp) extends GroupElement with WrapperOf[Ecp] {
 
+  private var _encoded: Coll[Byte] = null
   override def toString: String = s"GroupElement(${wrappedValue.showECPoint})"
 
-  override def getEncoded: Coll[Byte] =
-    Colls.fromArray(GroupElementSerializer.toBytes(wrappedValue))
+  override def getEncoded: Coll[Byte] = {
+    if(_encoded == null) {
+      _encoded = Colls.fromArray(GroupElementSerializer.toBytes(wrappedValue))
+    }
+    _encoded
+  }
 
   override def isIdentity: Boolean = CryptoFacade.isInfinityPoint(wrappedValue)
 
@@ -29,4 +34,11 @@ case class CGroupElement(override val wrappedValue: Ecp) extends GroupElement wi
 
   override def negate: GroupElement =
     CGroupElement(CryptoFacade.negatePoint(wrappedValue))
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case cg: GroupElement => cg.getEncoded == this.getEncoded
+      case _ => false
+    }
+  }
 }

--- a/core/shared/src/main/scala/sigma/data/CGroupElement.scala
+++ b/core/shared/src/main/scala/sigma/data/CGroupElement.scala
@@ -11,14 +11,10 @@ import sigma.{BigInt, Coll, Colls, GroupElement, UnsignedBigInt}
   */
 case class CGroupElement(override val wrappedValue: Ecp) extends GroupElement with WrapperOf[Ecp] {
 
-  private var _encoded: Coll[Byte] = null
   override def toString: String = s"GroupElement(${wrappedValue.showECPoint})"
 
   override def getEncoded: Coll[Byte] = {
-    if(_encoded == null) {
-      _encoded = Colls.fromArray(GroupElementSerializer.toBytes(wrappedValue))
-    }
-    _encoded
+    Colls.fromArray(GroupElementSerializer.toBytes(wrappedValue))
   }
 
   override def isIdentity: Boolean = CryptoFacade.isInfinityPoint(wrappedValue)
@@ -34,11 +30,4 @@ case class CGroupElement(override val wrappedValue: Ecp) extends GroupElement wi
 
   override def negate: GroupElement =
     CGroupElement(CryptoFacade.negatePoint(wrappedValue))
-
-  override def equals(obj: Any): Boolean = {
-    obj match {
-      case cg: GroupElement => cg.getEncoded == this.getEncoded
-      case _ => false
-    }
-  }
 }

--- a/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
+++ b/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
@@ -233,9 +233,6 @@ object ReflectionData {
         mkMethod(clazz, "reverse", Array[Class[_]]()) { (obj, args) =>
           obj.asInstanceOf[Coll[Any]].reverse
         },
-        mkMethod(clazz, "distinct", Array[Class[_]]()) { (obj, args) =>
-          obj.asInstanceOf[Coll[Any]].distinct
-        },
         mkMethod(clazz, "startsWith", Array[Class[_]](classOf[Coll[_]])) { (obj, args) =>
           obj.asInstanceOf[Coll[Any]].startsWith(args(0).asInstanceOf[Coll[Any]])
         },

--- a/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
+++ b/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
@@ -330,10 +330,6 @@ object SigmaDataReflection {
           obj.asInstanceOf[SCollectionMethods.type].reverse_eval(args(0).asInstanceOf[MethodCall],
             args(1).asInstanceOf[Coll[Any]])(args(2).asInstanceOf[ErgoTreeEvaluator])
         },
-        mkMethod(clazz, "distinct_eval", Array[Class[_]](classOf[MethodCall], classOf[Coll[_]], classOf[ErgoTreeEvaluator])) { (obj, args) =>
-          obj.asInstanceOf[SCollectionMethods.type].distinct_eval(args(0).asInstanceOf[MethodCall],
-            args(1).asInstanceOf[Coll[Any]])(args(2).asInstanceOf[ErgoTreeEvaluator])
-        },
         mkMethod(clazz, "startsWith_eval", Array[Class[_]](classOf[MethodCall], classOf[Coll[_]], classOf[Coll[_]], classOf[ErgoTreeEvaluator])) { (obj, args) =>
           obj.asInstanceOf[SCollectionMethods.type].startsWith_eval(args(0).asInstanceOf[MethodCall],
             args(1).asInstanceOf[Coll[Any]], args(2).asInstanceOf[Coll[Any]])(args(3).asInstanceOf[ErgoTreeEvaluator])

--- a/data/shared/src/main/scala/sigma/ast/methods.scala
+++ b/data/shared/src/main/scala/sigma/ast/methods.scala
@@ -1210,29 +1210,10 @@ object SCollectionMethods extends MethodsContainer with MethodByNameUnapply {
     }
   }
 
-  private val distinctCostKind = PerItemCost(baseCost = JitCost(60), perChunkCost = JitCost(5), chunkSize = 100)
-
-  val DistinctMethod = SMethod(this, "distinct",
-    SFunc(Array(ThisType), ThisType, paramIVSeq), 31, distinctCostKind)
-    .withIRInfo(MethodCallIrBuilder)
-    .withInfo(MethodCall, "Returns inversed collection.")
-
-  /** Implements evaluation of Coll.reverse method call ErgoTree node.
-    * Called via reflection based on naming convention.
-    * @see SMethod.evalMethod
-    */
-  def distinct_eval[A](mc: MethodCall, xs: Coll[A])
-                     (implicit E: ErgoTreeEvaluator): Coll[A] = {
-    val m = mc.method
-    E.addSeqCost(m.costKind.asInstanceOf[PerItemCost], xs.length, m.opDesc) { () =>
-      xs.distinct
-    }
-  }
-
   private val startsWithCostKind = Zip_CostKind
 
   val StartsWithMethod = SMethod(this, "startsWith",
-    SFunc(Array(ThisType, ThisType), SBoolean, paramIVSeq), 32, startsWithCostKind)
+    SFunc(Array(ThisType, ThisType), SBoolean, paramIVSeq), 31, startsWithCostKind)
     .withIRInfo(MethodCallIrBuilder)
     .withInfo(MethodCall, "Returns true if this collection starts with given one, false otherwise.",
       ArgInfo("prefix", "Collection to be checked for being a prefix of this collection."))
@@ -1252,7 +1233,7 @@ object SCollectionMethods extends MethodsContainer with MethodByNameUnapply {
   private val endsWithCostKind = Zip_CostKind
 
   val EndsWithMethod = SMethod(this, "endsWith",
-    SFunc(Array(ThisType, ThisType), SBoolean, paramIVSeq), 33, endsWithCostKind)
+    SFunc(Array(ThisType, ThisType), SBoolean, paramIVSeq), 32, endsWithCostKind)
     .withIRInfo(MethodCallIrBuilder)
     .withInfo(MethodCall, "Returns true if this collection ends with given one, false otherwise.",
       ArgInfo("suffix", "Collection to be checked for being a suffix of this collection."))
@@ -1270,7 +1251,7 @@ object SCollectionMethods extends MethodsContainer with MethodByNameUnapply {
   }
 
   val GetMethod = SMethod(this, "get",
-    SFunc(Array(ThisType, SInt), SOption(tIV), Array[STypeParam](tIV)), 34, ByIndex.costKind)
+    SFunc(Array(ThisType, SInt), SOption(tIV), Array[STypeParam](tIV)), 33, ByIndex.costKind)
     .withIRInfo(MethodCallIrBuilder)
     .withInfo(MethodCall,
               "Returns Some(element) if there is an element at given index, None otherwise.",
@@ -1299,7 +1280,6 @@ object SCollectionMethods extends MethodsContainer with MethodByNameUnapply {
 
   private val v6Methods = v5Methods ++ Seq(
     ReverseMethod,
-    DistinctMethod,
     StartsWithMethod,
     EndsWithMethod,
     GetMethod

--- a/data/shared/src/main/scala/sigma/ast/methods.scala
+++ b/data/shared/src/main/scala/sigma/ast/methods.scala
@@ -1196,7 +1196,7 @@ object SCollectionMethods extends MethodsContainer with MethodByNameUnapply {
   val ReverseMethod = SMethod(this, "reverse",
     SFunc(Array(ThisType), ThisType, paramIVSeq), 30, reverseCostKind)
     .withIRInfo(MethodCallIrBuilder)
-    .withInfo(MethodCall, "")
+    .withInfo(MethodCall, "Returns inversed collection.")
 
   /** Implements evaluation of Coll.reverse method call ErgoTree node.
     * Called via reflection based on naming convention.
@@ -1963,7 +1963,7 @@ case object SGlobalMethods extends MonoTypeMethods {
     CBigInt(Autolykos2PowValidation.hitForVersion2ForMessageWithChecks(k, msg.toArray, nonce.toArray, h.toArray, N).bigInteger)
   }
 
-  private val deserializeCostKind = PerItemCost(baseCost = JitCost(30), perChunkCost = JitCost(20), chunkSize = 32)
+  private val deserializeCostKind = PerItemCost(baseCost = JitCost(100), perChunkCost = JitCost(32), chunkSize = 32)
 
   lazy val deserializeToMethod = SMethod(
     this, "deserializeTo", SFunc(Array(SGlobal, SByteArray), tT, Array(paramT)), 4, deserializeCostKind, Seq(tT))

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -359,13 +359,7 @@ class Context {
     *  @return A new $coll with all elements of this $coll in reversed order.
     */
   def reverse: Coll[T]
-
-  /** Builds a new $coll from this $coll without any duplicate elements.
-    *
-    *  @return  A new $coll which contains the first occurrence of every element of this $coll.
-    */
-  def distinct: Coll[T]
-  
+ 
 }
 
 /** Represents data of the block headers available in scripts. */

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
@@ -1009,8 +1009,6 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
               xs.getOrElse(i, d)
             case SCollectionMethods.ReverseMethod.name =>
               xs.reverse
-            case SCollectionMethods.DistinctMethod.name =>
-              xs.distinct
             case SCollectionMethods.StartsWithMethod.name =>
               val ys = asRep[Coll[t]](argsV(0))
               xs.startsWith(ys)

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphIRReflection.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphIRReflection.scala
@@ -263,9 +263,6 @@ object GraphIRReflection {
         mkMethod(clazz, "reverse", Array[Class[_]]()) { (obj, _) =>
           obj.asInstanceOf[ctx.Coll[Any]].reverse
         },
-        mkMethod(clazz, "distinct", Array[Class[_]]()) { (obj, _) =>
-          obj.asInstanceOf[ctx.Coll[Any]].distinct
-        },
         mkMethod(clazz, "startsWith", Array[Class[_]](classOf[Base#Ref[_]])) { (obj, args) =>
           obj.asInstanceOf[ctx.Coll[Any]].startsWith(args(0).asInstanceOf[ctx.Ref[ctx.Coll[Any]]])
         },

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/CollsUnit.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/CollsUnit.scala
@@ -31,7 +31,6 @@ import sigma.compiler.ir.{Base, IRContext}
       def slice(from: Ref[Int], until: Ref[Int]): Ref[Coll[A]];
       def append(other: Ref[Coll[A]]): Ref[Coll[A]];
       def reverse: Ref[Coll[A]]
-      def distinct: Ref[Coll[A]]
       def startsWith(ys: Ref[Coll[A]]): Ref[Boolean];
       def endsWith(ys: Ref[Coll[A]]): Ref[Boolean];
     };

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/CollsImpl.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/CollsImpl.scala
@@ -180,13 +180,6 @@ class CollCls extends EntityObject("Coll") {
         true, false, element[Coll[A]]))
     }
 
-    override def distinct: Ref[Coll[A]] = {
-      asRep[Coll[A]](mkMethodCall(self,
-        CollClass.getMethod("distinct"),
-        Array[AnyRef](),
-        true, false, element[Coll[A]]))
-    }
-
     def startsWith(ys: Ref[Coll[A]]): Ref[Boolean] = {
       asRep[Boolean](mkMethodCall(self,
         CollClass.getMethod("startsWith", classOf[Sym]),
@@ -358,13 +351,6 @@ class CollCls extends EntityObject("Coll") {
     def reverse: Ref[Coll[A]] = {
       asRep[Coll[A]](mkMethodCall(source,
         CollClass.getMethod("reverse"),
-        Array[AnyRef](),
-        true, true, element[Coll[A]]))
-    }
-
-    def distinct: Ref[Coll[A]] = {
-      asRep[Coll[A]](mkMethodCall(source,
-        CollClass.getMethod("distinct"),
         Array[AnyRef](),
         true, true, element[Coll[A]]))
     }

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
@@ -2186,35 +2186,6 @@ class LanguageSpecificationV6 extends LanguageSpecificationBase { suite =>
     )
   }
 
-  property("Coll.distinct") {
-    val f = newFeature[Coll[Int], Coll[Int]](
-      { (xs: Coll[Int]) => xs.distinct },
-      """{(xs: Coll[Int]) => xs.distinct }""".stripMargin,
-      FuncValue(
-        Array((1, SCollectionType(SInt))),
-        MethodCall.typed[Value[SCollection[SInt.type]]](
-          ValUse(1, SCollectionType(SInt)),
-          SCollectionMethods.DistinctMethod.withConcreteTypes(Map(STypeVar("IV") -> SInt)),
-          IndexedSeq(),
-          Map()
-        )
-      ),
-      sinceVersion = VersionContext.V6SoftForkVersion
-    )
-
-    verifyCases(
-      Seq(
-        Coll(1, 2) -> Expected(ExpectedResult(Success(Coll(1, 2)), None)),
-        Coll(1, 1, 2) -> Expected(ExpectedResult(Success(Coll(1, 2)), None)),
-        Coll(1, 2, 2) -> Expected(ExpectedResult(Success(Coll(1, 2)), None)),
-        Coll(2, 2, 2) -> Expected(ExpectedResult(Success(Coll(2)), None)),
-        Coll(3, 1, 2, 2, 2, 4, 4, 1) -> Expected(ExpectedResult(Success(Coll(3, 1, 2, 4)), None)),
-        Coll[Int]() -> Expected(ExpectedResult(Success(Coll[Int]()), None))
-      ),
-      f
-    )
-  }
-
   property("Coll.startsWith") {
     val f = newFeature[(Coll[Int], Coll[Int]), Boolean](
       { (xs: (Coll[Int], Coll[Int])) => xs._1.startsWith(xs._2) },

--- a/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
@@ -577,36 +577,15 @@ class ErgoTreeSpecification extends SigmaDslTesting with ContractsTestkit with C
         MInfo(8, FilterMethod),
         MInfo(9, AppendMethod),
         MInfo(10, ApplyMethod),
-        /* TODO soft-fork: https://github.com/ScorexFoundation/sigmastate-interpreter/issues/479
-        BitShiftLeftMethod,
-        BitShiftRightMethod,
-        BitShiftRightZeroedMethod,
-        */
         MInfo(14, IndicesMethod),
         MInfo(15, FlatMapMethod),
         MInfo(19, PatchMethod),
         MInfo(20, UpdatedMethod),
         MInfo(21, UpdateManyMethod),
-        /*TODO soft-fork: https://github.com/ScorexFoundation/sigmastate-interpreter/issues/479
-        UnionSetsMethod,
-        DiffMethod,
-        IntersectMethod,
-        PrefixLengthMethod,
-        */
         MInfo(26, IndexOfMethod),
-        /* TODO soft-fork: https://github.com/ScorexFoundation/sigmastate-interpreter/issues/479
-        LastIndexOfMethod,
-        FindMethod,
-        */
         MInfo(29, ZipMethod)
-        /* TODO soft-fork: https://github.com/ScorexFoundation/sigmastate-interpreter/issues/479
-        DistinctMethod,
-        StartsWithMethod,
-        EndsWithMethod,
-        MapReduceMethod,
-        */
       ) ++ (if (isV6Activated) {
-        Seq(MInfo(30, ReverseMethod), MInfo(31, DistinctMethod), MInfo(32, StartsWithMethod), MInfo(33, EndsWithMethod), MInfo(34, GetMethod))
+        Seq(MInfo(30, ReverseMethod), MInfo(31, StartsWithMethod), MInfo(32, EndsWithMethod), MInfo(33, GetMethod))
       } else Seq.empty), true)
     },
     { import SOptionMethods._

--- a/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
@@ -24,7 +24,7 @@ import sigma.eval.EvalSettings
 import sigma.exceptions.{CostLimitException, InterpreterException}
 import sigma.serialization.ErgoTreeSerializer.DefaultSerializer
 import sigmastate.{CrossVersionProps, Plus}
-import sigmastate.utils.Helpers.TryOps
+import sigmastate.utils.Helpers.{TryOps, decodeGroupElement}
 
 
 /** Regression tests with ErgoTree related test vectors.

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -3227,9 +3227,11 @@ class BasicOpsSpecification extends CompilerTestingCommons
     if (activatedVersionInTests < V6SoftForkVersion) {
       an[sigma.validation.ValidationException] should be thrownBy distinctTest()
     } else {
-      val start = System.nanoTime()
+      val start = System.currentTimeMillis()
       distinctTest()
-      println("time: " + (System.nanoTime() - start) / 1000000)
+      val eta = System.currentTimeMillis() - start
+      println("time (s): " + eta / 1000)
+      (eta < 2000) shouldBe true
     }
   }
 

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -3200,4 +3200,37 @@ class BasicOpsSpecification extends CompilerTestingCommons
     }
   }
 
+  property("distinct - spam attempt") {
+    val customExt = Seq(21.toByte -> CollectionConstant[SGroupElement.type](
+      Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
+      SGroupElement),
+      22.toByte -> CollectionConstant[SGroupElement.type](
+        Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
+        SGroupElement), 23.toByte -> CollectionConstant[SGroupElement.type](
+        Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
+        SGroupElement), 24.toByte -> CollectionConstant[SGroupElement.type](
+        Colls.fromArray(Array.fill(1000)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
+        SGroupElement))
+    def distinctTest() = test("serialize", env, customExt,
+      s"""{
+            val coll1 = getVar[Coll[GroupElement]](21).get
+            val coll2 = getVar[Coll[GroupElement]](22).get
+            val coll3 = getVar[Coll[GroupElement]](23).get
+            val coll4 = getVar[Coll[GroupElement]](24).get
+
+            coll4.filter({(a: GroupElement) => coll1.distinct.size == coll2.distinct.size}).size != coll3.distinct.size
+          }""",
+      null,
+      true
+    )
+
+    if (activatedVersionInTests < V6SoftForkVersion) {
+      an[sigma.validation.ValidationException] should be thrownBy distinctTest()
+    } else {
+      val start = System.nanoTime()
+      distinctTest()
+      println("time: " + (System.nanoTime() - start) / 1000000)
+    }
+  }
+
 }

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -1487,27 +1487,6 @@ class BasicOpsSpecification extends CompilerTestingCommons
     }
   }
 
-  property("Coll.distinct"){
-    def reverseTest() = test("distinct", env, ext,
-      """{
-        | val c1 = Coll(1, 2, 3, 3, 2)
-        | val c2 = Coll(3, 2, 1)
-        |
-        | val h1 = Coll(INPUTS(0), INPUTS(0))
-        | val h2 = Coll(INPUTS(0))
-        |
-        | c1.distinct.reverse == c2 && h1.distinct == h2
-        | }""".stripMargin,
-      null
-    )
-
-    if(VersionContext.current.isV6SoftForkActivated) {
-      reverseTest()
-    } else {
-      an[sigma.validation.ValidationException] shouldBe thrownBy(reverseTest())
-    }
-  }
-
   property("Coll.startsWith"){
     def reverseTest() = test("distinct", env, ext,
       """{
@@ -3197,41 +3176,6 @@ class BasicOpsSpecification extends CompilerTestingCommons
       someTest()
     } else {
       an[sigma.validation.ValidationException] should be thrownBy someTest()
-    }
-  }
-
-  property("distinct - spam attempt") {
-    val customExt = Seq(21.toByte -> CollectionConstant[SGroupElement.type](
-      Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
-      SGroupElement),
-      22.toByte -> CollectionConstant[SGroupElement.type](
-        Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
-        SGroupElement), 23.toByte -> CollectionConstant[SGroupElement.type](
-        Colls.fromArray(Array.fill(65535)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
-        SGroupElement), 24.toByte -> CollectionConstant[SGroupElement.type](
-        Colls.fromArray(Array.fill(1000)(decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b"))),
-        SGroupElement))
-    def distinctTest() = test("serialize", env, customExt,
-      s"""{
-            val coll1 = getVar[Coll[GroupElement]](21).get
-            val coll2 = getVar[Coll[GroupElement]](22).get
-            val coll3 = getVar[Coll[GroupElement]](23).get
-            val coll4 = getVar[Coll[GroupElement]](24).get
-
-            coll4.filter({(a: GroupElement) => coll1.distinct.size == coll2.distinct.size}).size != coll3.distinct.size
-          }""",
-      null,
-      true
-    )
-
-    if (activatedVersionInTests < V6SoftForkVersion) {
-      an[sigma.validation.ValidationException] should be thrownBy distinctTest()
-    } else {
-      val start = System.currentTimeMillis()
-      distinctTest()
-      val eta = System.currentTimeMillis() - start
-      println("time (s): " + eta / 1000)
-      (eta < 2000) shouldBe true
     }
   }
 


### PR DESCRIPTION
In this PR, coll.distinct method, earlier introduced in 6.0.0 candidate, has been removed, as it may be used for DoS attacks, see #1051 for details. Another alternative was to use type-based recursive cost evaluation like done in DataSerializer, but removing is simpler, and in case of need distinct check can be done in ErgoScript for small collections. 

Close #1051 