### PR TITLE
use secp256k1-jni for EC scalar multiplication, BC as fallback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,8 @@ lazy val core   = crossProject(JVMPlatform, JSPlatform)
   .jvmSettings(
     crossScalaSettings,
     libraryDependencies ++= Seq(
-      bouncycastleBcprov
+      bouncycastleBcprov,
+      "org.bitcoin-s" % "bitcoin-s-secp256k1jni" % "1.9.10"
     )
   )
   .jsSettings(

--- a/core/jvm/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/Platform.scala
@@ -106,8 +106,16 @@ object Platform {
     /*
      * BC treats EC as additive group while we treat that as multiplicative group.
      * Therefore, exponentiate point is multiply.
+     * Use native libsecp256k1 when available; fall back to BouncyCastle otherwise.
      */
-    Ecp(p.value.multiply(n))
+    if (SecP256K1Native.isEnabled && !p.value.isInfinity) {
+      SecP256K1Native.multiplyPointByScalar(p.value, n) match {
+        case Some(result) => Ecp(result)
+        case None         => Ecp(p.value.multiply(n))  // n == 0 → infinity via BC
+      }
+    } else {
+      Ecp(p.value.multiply(n))
+    }
   }
 
   /** Check if a point is infinity. */

--- a/core/jvm/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/Platform.scala
@@ -111,7 +111,7 @@ object Platform {
     if (SecP256K1Native.isEnabled && !p.value.isInfinity) {
       SecP256K1Native.multiplyPointByScalar(p.value, n) match {
         case Some(result) => Ecp(result)
-        case None         => Ecp(p.value.multiply(n))  // n == 0 → infinity via BC
+        case None         => Ecp(p.value.multiply(n))  // n ≡ 0 (mod order) → infinity via BC
       }
     } else {
       Ecp(p.value.multiply(n))

--- a/core/jvm/src/main/scala/sigma/crypto/SecP256K1Native.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/SecP256K1Native.scala
@@ -1,0 +1,51 @@
+package sigma.crypto
+
+import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
+import org.bouncycastle.crypto.ec.CustomNamedCurves
+import org.bouncycastle.math.ec.ECPoint
+
+import java.math.BigInteger
+
+/** Native secp256k1 backend via bitcoin-s JNI wrapper.
+  * Falls back transparently when native lib is not available.
+  */
+private[crypto] object SecP256K1Native {
+
+  /** True if the native libsecp256k1 loaded successfully on this platform. */
+  val isEnabled: Boolean = Secp256k1Context.isEnabled
+
+  private lazy val x9params  = CustomNamedCurves.getByName("secp256k1")
+  private lazy val curve      = x9params.getCurve
+  private lazy val groupOrder = x9params.getN
+
+  /** EC scalar multiplication using the native library.
+    * Returns None when the effective scalar is 0 (result is the point at infinity) or on any
+    * error, so the caller can fall back to BouncyCastle.
+    */
+  def multiplyPointByScalar(point: ECPoint, n: BigInteger): Option[ECPoint] = {
+    // secp256k1-jni requires a positive scalar in [1, order-1]; normalise negative inputs.
+    val scalar = if (n.signum() < 0) n.mod(groupOrder) else n
+    if (scalar.signum() == 0) return None
+    try {
+      val pointBytes  = point.getEncoded(true)     // compressed, 33 bytes
+      val scalarBytes = toScalarBytes(scalar)       // unsigned, exactly 32 bytes
+      val result      = NativeSecp256k1.pubKeyTweakMul(pointBytes, scalarBytes, true)
+      Some(curve.decodePoint(result))
+    } catch {
+      case _: Exception => None
+    }
+  }
+
+  // BigInteger.toByteArray() is signed and variable-length; secp256k1 needs 32 unsigned bytes.
+  private def toScalarBytes(n: BigInteger): Array[Byte] = {
+    val raw = n.toByteArray
+    raw.length match {
+      case 33  => raw.tail  // drop leading 0x00 sign byte
+      case 32  => raw
+      case len =>
+        val padded = new Array[Byte](32)
+        System.arraycopy(raw, 0, padded, 32 - len, len)
+        padded
+    }
+  }
+}

--- a/core/jvm/src/main/scala/sigma/crypto/SecP256K1Native.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/SecP256K1Native.scala
@@ -19,12 +19,14 @@ private[crypto] object SecP256K1Native {
   private lazy val groupOrder = x9params.getN
 
   /** EC scalar multiplication using the native library.
-    * Returns None when the effective scalar is 0 (result is the point at infinity) or on any
-    * error, so the caller can fall back to BouncyCastle.
+    * Returns None when the scalar is congruent to 0 modulo the group order (result is the point
+    * at infinity) or on any error, so the caller can fall back to BouncyCastle.
     */
   def multiplyPointByScalar(point: ECPoint, n: BigInteger): Option[ECPoint] = {
-    // secp256k1-jni requires a positive scalar in [1, order-1]; normalise negative inputs.
-    val scalar = if (n.signum() < 0) n.mod(groupOrder) else n
+    // secp256k1-jni accepts only a 32-byte scalar in [1, order-1]. Every non-infinity point of
+    // secp256k1 has exactly `groupOrder` as its order, so p * n == p * (n mod order) for any
+    // integer n (negative, or wider than 256 bits), which is what BouncyCastle computes.
+    val scalar = n.mod(groupOrder)
     if (scalar.signum() == 0) return None
     try {
       val pointBytes  = point.getEncoded(true)     // compressed, 33 bytes
@@ -36,16 +38,16 @@ private[crypto] object SecP256K1Native {
     }
   }
 
-  // BigInteger.toByteArray() is signed and variable-length; secp256k1 needs 32 unsigned bytes.
+  /** Big-endian unsigned 32-byte encoding of `n`, which must be in [0, 2^256).
+    * BigInteger.toByteArray() is signed and variable-length: it may carry a leading 0x00 sign
+    * byte (33 bytes for values with bit 255 set) or be shorter than 32 bytes.
+    */
   private def toScalarBytes(n: BigInteger): Array[Byte] = {
+    require(n.signum() >= 0 && n.bitLength() <= 256, s"scalar out of range: $n")
     val raw = n.toByteArray
-    raw.length match {
-      case 33  => raw.tail  // drop leading 0x00 sign byte
-      case 32  => raw
-      case len =>
-        val padded = new Array[Byte](32)
-        System.arraycopy(raw, 0, padded, 32 - len, len)
-        padded
-    }
+    val padded = new Array[Byte](32)
+    val len = math.min(raw.length, 32)
+    System.arraycopy(raw, raw.length - len, padded, 32 - len, len)
+    padded
   }
 }

--- a/core/jvm/src/test/scala/sigma/crypto/SecP256K1NativeSpec.scala
+++ b/core/jvm/src/test/scala/sigma/crypto/SecP256K1NativeSpec.scala
@@ -1,0 +1,258 @@
+package sigma.crypto
+
+import org.bouncycastle.math.ec.ECPoint
+import org.scalacheck.Gen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.math.BigInteger
+import java.util.concurrent.{Callable, Executors, TimeUnit}
+import scala.collection.JavaConverters._
+
+/** Checks that EC scalar multiplication routed through native libsecp256k1
+  * ([[SecP256K1Native]]) is indistinguishable from the BouncyCastle reference
+  * implementation, for random inputs and for every edge case of the fallback logic.
+  *
+  * `Platform.exponentiatePoint` is consensus-critical: any input on which the two
+  * backends disagree would fork the network, so the comparison is on encoded bytes.
+  */
+class SecP256K1NativeSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
+
+  private val ctx: CryptoContextJvm = Platform.createContext().asInstanceOf[CryptoContextJvm]
+  private val order: BigInteger = ctx.order
+  private val G: ECPoint = ctx.generator.value
+  private val infinity: ECPoint = ctx.infinity().value
+  private val two256: BigInteger = BigInteger.ONE.shiftLeft(256)
+
+  /** Pure BouncyCastle reference (what every node computed before this change). */
+  private def reference(p: ECPoint, n: BigInteger): ECPoint = p.multiply(n)
+
+  private def encode(p: ECPoint): Seq[Byte] = p.getEncoded(true).toSeq
+
+  /** Both backends must agree on the point at infinity and on the compressed encoding. */
+  private def assertSamePoint(actual: ECPoint, expected: ECPoint, clue: => String): Unit = {
+    withClue(clue) {
+      actual.isInfinity shouldBe expected.isInfinity
+      if (!expected.isInfinity) {
+        actual.isValid shouldBe true
+        encode(actual) shouldBe encode(expected)
+      }
+    }
+  }
+
+  private def checkAgainstReference(p: ECPoint, n: BigInteger): Unit = {
+    val expected = reference(p, n)
+    val viaPlatform = Platform.exponentiatePoint(Platform.Ecp(p), n).value
+    assertSamePoint(viaPlatform, expected, s"Platform.exponentiatePoint, n=$n")
+
+    if (SecP256K1Native.isEnabled && !p.isInfinity) {
+      SecP256K1Native.multiplyPointByScalar(p, n) match {
+        case Some(native) => assertSamePoint(native, expected, s"native path, n=$n")
+        case None =>
+          // The native path may only decline when the result is infinity (n ≡ 0 mod order);
+          // everything else must be handled natively, otherwise the backend is not exercised.
+          withClue(s"native path returned None for n=$n, but reference result is not infinity") {
+            expected.isInfinity shouldBe true
+          }
+      }
+    }
+  }
+
+  // ----- generators -----------------------------------------------------------------------
+
+  private val bytes32: Gen[Array[Byte]] = Gen.containerOfN[Array, Byte](32, Gen.choose(Byte.MinValue, Byte.MaxValue))
+
+  /** Uniform scalar in [1, order-1]: the range accepted by libsecp256k1. */
+  private val inRangeScalar: Gen[BigInteger] =
+    bytes32.map(b => new BigInteger(1, b).mod(order)).suchThat(_.signum != 0)
+
+  /** Uniform signed 256-bit integer: the value range of ErgoTree's BigInt type. */
+  private val signed256: Gen[BigInteger] = bytes32.map(b => new BigInteger(b))
+
+  private val smallScalar: Gen[BigInteger] = Gen.choose(-1000L, 1000L).map(BigInteger.valueOf)
+
+  /** Scalars outside [1, order-1] that libsecp256k1 rejects and the fallback must handle. */
+  private val outOfRangeScalar: Gen[BigInteger] = Gen.oneOf(
+    Gen.choose(0L, 1000L).map(k => order.add(BigInteger.valueOf(k))),
+    Gen.choose(0L, 1000L).map(k => order.subtract(BigInteger.valueOf(k)).negate()),
+    Gen.choose(1L, 1000L).map(k => order.multiply(BigInteger.valueOf(k))),
+    Gen.choose(0L, 1000L).map(k => two256.add(BigInteger.valueOf(k))),
+    inRangeScalar.map(k => order.multiply(BigInteger.valueOf(7)).add(k)),
+    inRangeScalar.map(k => two256.multiply(BigInteger.valueOf(3)).add(k).negate())
+  )
+
+  private val anyScalar: Gen[BigInteger] = Gen.frequency(
+    4 -> inRangeScalar, 3 -> signed256, 2 -> smallScalar, 2 -> outOfRangeScalar
+  )
+
+  /** Random curve point, produced by BC so it is independent of the code under test. */
+  private val randomPoint: Gen[ECPoint] = inRangeScalar.map(k => G.multiply(k))
+
+  private val anyPoint: Gen[ECPoint] = Gen.frequency(
+    6 -> randomPoint,
+    1 -> Gen.const(G),
+    1 -> Gen.const(G.negate()),
+    1 -> randomPoint.map(_.negate()),
+    1 -> Gen.const(infinity)
+  )
+
+  private val minSuccessful = MinSuccessful(500)
+
+  // ----- properties -----------------------------------------------------------------------
+
+  property("native library status is reported") {
+    info(s"native libsecp256k1 enabled: ${SecP256K1Native.isEnabled}")
+    // Not an assertion: on platforms without a bundled native lib the BC fallback is used
+    // and every test in this suite still verifies the fallback against the reference.
+  }
+
+  property("exponentiatePoint agrees with BouncyCastle for random points and scalars") {
+    forAll(anyPoint, anyScalar, minSuccessful) { (p, n) => checkAgainstReference(p, n) }
+  }
+
+  property("exponentiatePoint agrees with BouncyCastle on the full ErgoTree BigInt range") {
+    forAll(randomPoint, signed256, minSuccessful) { (p, n) => checkAgainstReference(p, n) }
+  }
+
+  property("native path is taken for every scalar in [1, order-1]") {
+    assume(SecP256K1Native.isEnabled, "native libsecp256k1 not available on this platform")
+    forAll(randomPoint, inRangeScalar, minSuccessful) { (p, n) =>
+      val res = SecP256K1Native.multiplyPointByScalar(p, n)
+      res shouldBe defined
+      assertSamePoint(res.get, reference(p, n), s"n=$n")
+    }
+  }
+
+  property("exponentiation is a group homomorphism (p^(a+b) == p^a * p^b, p^(ab) == (p^a)^b)") {
+    forAll(randomPoint, inRangeScalar, inRangeScalar, MinSuccessful(100)) { (p, a, b) =>
+      def exp(q: ECPoint, k: BigInteger) = Platform.exponentiatePoint(Platform.Ecp(q), k).value
+      assertSamePoint(exp(p, a.add(b)), exp(p, a).add(exp(p, b)), "additive")
+      assertSamePoint(exp(p, a.multiply(b)), exp(exp(p, a), b), "multiplicative")
+    }
+  }
+
+  property("accepts non-normalized (projective) input points") {
+    forAll(randomPoint, inRangeScalar, inRangeScalar, MinSuccessful(100)) { (p, a, b) =>
+      val projective = p.multiply(a)   // BC leaves the result in Jacobian coordinates
+      projective.isNormalized shouldBe false
+      checkAgainstReference(projective, b)
+    }
+  }
+
+  // ----- edge cases -----------------------------------------------------------------------
+
+  private val edgeScalars: Seq[(String, BigInteger)] = Seq(
+    "0"            -> BigInteger.ZERO,
+    "1"            -> BigInteger.ONE,
+    "2"            -> BigInteger.valueOf(2),
+    "-1"           -> BigInteger.ONE.negate(),
+    "-2"           -> BigInteger.valueOf(-2),
+    "order-1"      -> order.subtract(BigInteger.ONE),
+    "order"        -> order,
+    "order+1"      -> order.add(BigInteger.ONE),
+    "-(order-1)"   -> order.subtract(BigInteger.ONE).negate(),
+    "-order"       -> order.negate(),
+    "-(order+1)"   -> order.add(BigInteger.ONE).negate(),
+    "2*order"      -> order.shiftLeft(1),
+    "2*order+1"    -> order.shiftLeft(1).add(BigInteger.ONE),
+    "2^255"        -> BigInteger.ONE.shiftLeft(255),          // 32 bytes, high bit set
+    "2^255-1"      -> BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE), // max ErgoTree BigInt
+    "-2^255"       -> BigInteger.ONE.shiftLeft(255).negate(), // min ErgoTree BigInt
+    "2^256-1"      -> two256.subtract(BigInteger.ONE),        // max unsigned 32-byte value
+    "2^256"        -> two256,                                 // 33 significant bytes
+    "2^256+1"      -> two256.add(BigInteger.ONE),
+    "2^256+order"  -> two256.add(order),
+    "-(2^256+1)"   -> two256.add(BigInteger.ONE).negate(),
+    "2^300+12345"  -> BigInteger.ONE.shiftLeft(300).add(BigInteger.valueOf(12345)),
+    "2^1000"       -> BigInteger.ONE.shiftLeft(1000),
+    "order^2"      -> order.multiply(order),
+    "order^2+1"    -> order.multiply(order).add(BigInteger.ONE)
+  )
+
+  private val edgePoints: Seq[(String, ECPoint)] = Seq(
+    "G"        -> G,
+    "-G"       -> G.negate(),
+    "2G"       -> G.twice(),
+    "(order-1)G" -> G.multiply(order.subtract(BigInteger.ONE)),
+    "infinity" -> infinity
+  )
+
+  property("edge-case scalars agree with BouncyCastle on edge-case points") {
+    for ((pName, p) <- edgePoints; (nName, n) <- edgeScalars) {
+      withClue(s"point=$pName scalar=$nName: ") { checkAgainstReference(p, n) }
+    }
+  }
+
+  property("scalar 0 and multiples of the order give the point at infinity") {
+    for (n <- Seq(BigInteger.ZERO, order, order.negate(), order.shiftLeft(1), order.multiply(order))) {
+      Platform.isInfinityPoint(Platform.exponentiatePoint(Platform.Ecp(G), n)) shouldBe true
+      if (SecP256K1Native.isEnabled) {
+        SecP256K1Native.multiplyPointByScalar(G, n) shouldBe None
+      }
+    }
+  }
+
+  property("exponentiating the point at infinity gives infinity for any scalar") {
+    for ((_, n) <- edgeScalars) {
+      Platform.isInfinityPoint(Platform.exponentiatePoint(Platform.Ecp(infinity), n)) shouldBe true
+    }
+  }
+
+  property("scalar 1 is the identity and -1 is negation") {
+    forAll(randomPoint, MinSuccessful(50)) { p =>
+      assertSamePoint(Platform.exponentiatePoint(Platform.Ecp(p), BigInteger.ONE).value, p, "p^1")
+      assertSamePoint(Platform.exponentiatePoint(Platform.Ecp(p), BigInteger.ONE.negate()).value, p.negate(), "p^-1")
+      assertSamePoint(Platform.exponentiatePoint(Platform.Ecp(p), order.subtract(BigInteger.ONE)).value, p.negate(), "p^(order-1)")
+    }
+  }
+
+  property("negative scalars and scalars beyond the order reduce modulo the order") {
+    forAll(randomPoint, inRangeScalar, Gen.choose(-5L, 5L), MinSuccessful(100)) { (p, k, m) =>
+      val n = k.add(order.multiply(BigInteger.valueOf(m)))
+      assertSamePoint(
+        Platform.exponentiatePoint(Platform.Ecp(p), n).value,
+        Platform.exponentiatePoint(Platform.Ecp(p), k).value,
+        s"k=$k m=$m")
+    }
+  }
+
+  property("known-answer: small multiples of the generator") {
+    // Compressed encodings of 2G and 3G from the secp256k1 test vectors.
+    val twoG   = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+    val threeG = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+    def hex(p: ECPoint) = p.getEncoded(true).map("%02x".format(_)).mkString
+    hex(Platform.exponentiatePoint(Platform.Ecp(G), BigInteger.valueOf(2)).value) shouldBe twoG
+    hex(Platform.exponentiatePoint(Platform.Ecp(G), BigInteger.valueOf(3)).value) shouldBe threeG
+  }
+
+  property("results are consistent under concurrent use from many threads") {
+    val nThreads = 16
+    val perThread = 200
+    val inputs: Seq[(ECPoint, BigInteger)] = {
+      val rnd = new scala.util.Random(0xC0FFEE)
+      Seq.fill(nThreads * perThread) {
+        val b = new Array[Byte](32); rnd.nextBytes(b)
+        val k = new BigInteger(1, b).mod(order).add(BigInteger.ONE)
+        val pb = new Array[Byte](32); rnd.nextBytes(pb)
+        (G.multiply(new BigInteger(1, pb).mod(order).add(BigInteger.ONE)), k)
+      }
+    }
+    val expected = inputs.map { case (p, n) => encode(reference(p, n)) }
+
+    val pool = Executors.newFixedThreadPool(nThreads)
+    try {
+      val tasks = inputs.grouped(perThread).map { chunk =>
+        new Callable[Seq[Seq[Byte]]] {
+          def call(): Seq[Seq[Byte]] =
+            chunk.map { case (p, n) => encode(Platform.exponentiatePoint(Platform.Ecp(p), n).value) }
+        }
+      }.toList
+      val futures = pool.invokeAll(tasks.asJava)
+      val actual = futures.asScala.flatMap(_.get(60, TimeUnit.SECONDS)).toSeq
+      actual shouldBe expected
+    } finally {
+      pool.shutdownNow()
+    }
+  }
+}


### PR DESCRIPTION
Adds bitcoin-s-secp256k1jni as a JVM-only dependency and routes exponentiatePoint through NativeSecp256k1.pubKeyTweakMul when the native library is available, falling back to BouncyCastle otherwise.

Closes #970 