### PR TITLE
reject improper DHT secrets at construction and signing time

### DIFF
--- a/interpreter/js/src/main/scala/sigma/interpreter/js/ProverSecret.scala
+++ b/interpreter/js/src/main/scala/sigma/interpreter/js/ProverSecret.scala
@@ -42,7 +42,7 @@ object ProverSecret extends js.Object {
   def dht(w: js.BigInt, dhtProp: SigmaProp): ProverSecret = {
     dhtProp.sigmaBoolean match {
       case dht: ProveDHTuple =>
-        val input = DiffieHellmanTupleProverInput(Isos.isoBigInt.to(w).toBigInteger, dht)
+        val input = DiffieHellmanTupleProverInput.create(Isos.isoBigInt.to(w).toBigInteger, dht)
         new ProverSecret(input)
       case _ => throw new Exception("Expected ProveDHTuple sigma proposition")
     }

--- a/interpreter/shared/src/main/scala/sigmastate/crypto/DiffieHellmanTupleProtocol.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/crypto/DiffieHellmanTupleProtocol.scala
@@ -12,11 +12,44 @@ case class DiffieHellmanTupleProverInput(w: BigInteger, commonInput: ProveDHTupl
   extends SigmaProtocolPrivateInput[ProveDHTuple] {
 
   override lazy val publicImage: ProveDHTuple = commonInput
+
+  /** Whether the secret `w` is consistent with the public statement. Cached so
+    * repeated checks during signing are cheap. Always `true` for instances
+    * built via [[DiffieHellmanTupleProverInput.create]] / `random`, but kept
+    * as defense-in-depth against reflective / deserialised input.
+    */
+  lazy val isValidSecret: Boolean =
+    DiffieHellmanTupleProverInput.isValid(w, commonInput)
+
+  /** Shadow the synthetic public `copy` so callers cannot side-step the
+    * validating factory by writing `existing.copy(w = badW)`.
+    */
+  private def copy(
+    w: BigInteger = this.w,
+    commonInput: ProveDHTuple = this.commonInput
+  ) = DiffieHellmanTupleProverInput.create(w, commonInput)
 }
 
 object DiffieHellmanTupleProverInput {
 
   import CryptoConstants.dlogGroup
+
+  /** Check that `w` satisfies the DH-tuple statement `(g, h, u, v)`, i.e.
+    * that `g^w == u` and `h^w == v`.
+    */
+  def isValid(w: BigInteger, dh: ProveDHTuple): Boolean = {
+    dlogGroup.exponentiate(dh.g, w) == dh.u &&
+      dlogGroup.exponentiate(dh.h, w) == dh.v
+  }
+
+  /** Validating factory: builds a [[DiffieHellmanTupleProverInput]] only if `w`
+    * actually satisfies the given DH-tuple statement. Throws
+    * `IllegalArgumentException` otherwise.
+    */
+  def create(w: BigInteger, dh: ProveDHTuple): DiffieHellmanTupleProverInput = {
+    require(isValid(w, dh), "Secret w does not satisfy the given ProveDHTuple statement (g^w != u or h^w != v)")
+    new DiffieHellmanTupleProverInput(w, dh)
+  }
 
   def random(): DiffieHellmanTupleProverInput = {
     val g = dlogGroup.generator
@@ -27,7 +60,7 @@ object DiffieHellmanTupleProverInput {
     val u = dlogGroup.exponentiate(g, w)
     val v = dlogGroup.exponentiate(h, w)
     val ci = ProveDHTuple(g, h, u, v)
-    DiffieHellmanTupleProverInput(w, ci)
+    DiffieHellmanTupleProverInput.create(w, ci)
   }
 }
 

--- a/interpreter/shared/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
@@ -528,6 +528,17 @@ trait ProverInterpreter extends Interpreter with ProverUtils {
         .filter(_.isInstanceOf[DiffieHellmanTupleProverInput])
         .find(_.asInstanceOf[DiffieHellmanTupleProverInput].publicImage == dhu.proposition)
 
+      // Defense-in-depth: even if a private input is matched by publicImage equality, its secret `w` may not
+      // actually satisfy the statement (e.g. when constructed bypassing `DiffieHellmanTupleProverInput.create`).
+      // Signing with such an input would produce a proof that the verifier rejects; fail loudly instead.
+      privKeyOpt.foreach { pk =>
+        val dhPk = pk.asInstanceOf[DiffieHellmanTupleProverInput]
+        if (!dhPk.isValidSecret) {
+          throw new InterpreterException(
+            s"DiffieHellmanTupleProverInput secret does not satisfy proposition at position ${dhu.position}")
+        }
+      }
+
       val z = privKeyOpt match {
         case Some(privKey) =>
           hintsBag.ownCommitments.find(_.position == dhu.position).map { oc =>

--- a/interpreter/shared/src/test/scala/sigmastate/crypto/DiffieHellmanTupleProverInputSpec.scala
+++ b/interpreter/shared/src/test/scala/sigmastate/crypto/DiffieHellmanTupleProverInputSpec.scala
@@ -1,0 +1,52 @@
+package sigmastate.crypto
+
+import java.math.BigInteger
+
+import org.scalatest.propspec.AnyPropSpec
+import sigma.crypto.CryptoConstants
+import sigma.data.ProveDHTuple
+import sigmastate.TestsBase
+
+class DiffieHellmanTupleProverInputSpec extends AnyPropSpec with TestsBase {
+  private val dlogGroup = CryptoConstants.dlogGroup
+
+  private def freshGenerator() = dlogGroup.createRandomGenerator()
+
+  property("isValid accepts a consistent (w, g, h, g^w, h^w) tuple") {
+    val honest = DiffieHellmanTupleProverInput.random()
+    DiffieHellmanTupleProverInput.isValid(honest.w, honest.commonInput) shouldBe true
+    honest.isValidSecret shouldBe true
+  }
+
+  property("isValid rejects an inconsistent secret (random w against fixed tuple)") {
+    val honest = DiffieHellmanTupleProverInput.random()
+    val bogus = honest.w.add(BigInteger.ONE).mod(dlogGroup.order)
+    DiffieHellmanTupleProverInput.isValid(bogus, honest.commonInput) shouldBe false
+  }
+
+  property("isValid rejects when only one of g^w, h^w matches") {
+    val g = dlogGroup.generator
+    val h = freshGenerator()
+    val w = DiffieHellmanTupleProverInput.random().w
+    val u = dlogGroup.exponentiate(g, w)
+    // v is bogus — exponent differs from w
+    val v = dlogGroup.exponentiate(h, w.add(BigInteger.ONE).mod(dlogGroup.order))
+    DiffieHellmanTupleProverInput.isValid(w, ProveDHTuple(g, h, u, v)) shouldBe false
+  }
+
+  property("create throws on inconsistent secret") {
+    val honest = DiffieHellmanTupleProverInput.random()
+    val bogus = honest.w.add(BigInteger.ONE).mod(dlogGroup.order)
+    assertThrows[IllegalArgumentException] {
+      DiffieHellmanTupleProverInput.create(bogus, honest.commonInput)
+    }
+  }
+
+  property("create succeeds and returns equivalent input for a valid secret") {
+    val honest = DiffieHellmanTupleProverInput.random()
+    val viaFactory = DiffieHellmanTupleProverInput.create(honest.w, honest.commonInput)
+    viaFactory.w shouldBe honest.w
+    viaFactory.commonInput shouldBe honest.commonInput
+    viaFactory.isValidSecret shouldBe true
+  }
+}

--- a/sc/shared/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -10,9 +10,12 @@ import sigma.ast.SCollection.SByteArray
 import sigma.ast._
 import sigmastate._
 import sigma.ast.syntax._
+import sigma.crypto.{BigIntegers, CryptoConstants}
 import sigma.data.{AvlTreeData, CBox, ProveDHTuple, ProveDlog, TrivialProp}
+import sigma.exceptions.InterpreterException
 import sigma.util.Extensions.EcpOps
 import sigma.validation.{ReplacedRule, ValidationException, ValidationRules}
+import sigmastate.crypto.DiffieHellmanTupleProverInput
 import sigmastate.eval._
 import sigmastate.interpreter.Interpreter._
 import sigmastate.helpers._
@@ -107,6 +110,57 @@ class ErgoLikeInterpreterSpecification extends CompilerTestingCommons
 
     fakeProver.prove(propTree, ctx, fakeMessage).isSuccess shouldBe false
     prover.prove(mkTestErgoTree(wrongProp), ctx, fakeMessage).isSuccess shouldBe false
+  }
+
+  property("DH tuple - signing w. proper and improper secrets") {
+    val verifier = new ErgoLikeTestInterpreter
+    val ctx = ErgoLikeContextTesting(
+      currentHeight = 1,
+      lastBlockUtxoRoot = AvlTreeData.dummy,
+      minerPubkey = ErgoLikeContextTesting.dummyPubkey,
+      boxesToSpend = IndexedSeq(fakeSelf),
+      spendingTransaction = ErgoLikeTransactionTesting.dummy,
+      self = fakeSelf, activatedVersionInTests)
+
+    // proveDHTuple(g, g^x, g^y, g^xy) should work for y and only for y, not for x:
+    // the statement is "I know w such that g^w == g^y and (g^x)^w == g^xy", which holds for w == y only.
+    val group = CryptoConstants.dlogGroup
+    val g = group.generator
+    val qMinusOne = group.order.subtract(BigInteger.ONE)
+
+    val x = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, group.secureRandom)
+    val gToX = group.exponentiate(g, x)
+
+    val y = BigIntegers.createRandomInRange(BigInteger.ZERO, qMinusOne, group.secureRandom)
+    val gToY = group.exponentiate(g, y)
+    val gToXY = group.exponentiate(gToX, y)
+    group.exponentiate(gToY, x) shouldBe gToXY
+
+    val dht = ProveDHTuple(g, gToX, gToY, gToXY)
+    val dhPropTree = mkTestErgoTree(SigmaPropConstant(dht))
+
+    // The validating factory rejects the improper secret x at construction time ...
+    assertThrows[IllegalArgumentException] {
+      DiffieHellmanTupleProverInput.create(x, dht)
+    }
+
+    // ... so bypass it via the primary constructor to reach the signing-time check.
+    val xSecret = new DiffieHellmanTupleProverInput(x, dht)
+    xSecret.isValidSecret shouldBe false
+    val proverX = new ContextEnrichingTestProvingInterpreter().withDHSecrets(Seq(xSecret)) // prover holding x
+
+    val ySecret = DiffieHellmanTupleProverInput.create(y, dht)
+    val proverY = new ContextEnrichingTestProvingInterpreter().withDHSecrets(Seq(ySecret)) // prover holding y
+
+    // should not work for x: signing fails loudly instead of producing a proof the verifier would reject
+    // (PR #636 expressed this as an always-failing `prove(...).get shouldBe false` repro for #638)
+    val failure = proverX.prove(dhPropTree, ctx, fakeMessage).failure.exception
+    failure shouldBe an[InterpreterException]
+    failure.getMessage should include("does not satisfy proposition")
+
+    // should work for y
+    val proofY = proverY.prove(dhPropTree, ctx, fakeMessage).get
+    verifier.verify(dhPropTree, ctx, proofY, fakeMessage).get._1 shouldBe true
   }
 
   property("DH tuple - simulation") {

--- a/sc/shared/src/test/scala/sigmastate/utxo/examples/DHTupleExampleSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/examples/DHTupleExampleSpecification.scala
@@ -86,7 +86,7 @@ class DHTupleExampleSpecification extends CompilerTestingCommons
       spendingTransaction = tx,
       self = inBox, activatedVersionInTests
     )
-    val dhtBob = DiffieHellmanTupleProverInput(y, ProveDHTuple(g, g_x, g_y, g_xy))
+    val dhtBob = DiffieHellmanTupleProverInput.create(y, ProveDHTuple(g, g_x, g_y, g_xy))
 
     val proofBob = (new ContextEnrichingTestProvingInterpreter).withDHSecrets(
       Seq(dhtBob)
@@ -94,7 +94,7 @@ class DHTupleExampleSpecification extends CompilerTestingCommons
 
     verifier.verify(env, script, context, proofBob, fakeMessage).get._1 shouldBe true
 
-    val dhtAlice = DiffieHellmanTupleProverInput(x, ProveDHTuple(g, g_y, g_x, g_xy))
+    val dhtAlice = DiffieHellmanTupleProverInput.create(x, ProveDHTuple(g, g_y, g_x, g_xy))
 
     val proofAlice = (new ContextEnrichingTestProvingInterpreter).withDHSecrets(
       Seq(dhtAlice)
@@ -102,13 +102,9 @@ class DHTupleExampleSpecification extends CompilerTestingCommons
 
     verifier.verify(env, script, context, proofAlice, fakeMessage).get._1 shouldBe true
 
-    val dhtBad = DiffieHellmanTupleProverInput(BigInt(10).bigInteger, ProveDHTuple(g, g_y, g_x, g_xy))
-
-    val proofBad = (new ContextEnrichingTestProvingInterpreter).withDHSecrets(
-      Seq(dhtBad)
-    ).prove(env, script, context, fakeMessage).get.proof
-
-    verifier.verify(env, script, context, proofBad, fakeMessage).get._1 shouldBe false
+    assertThrows[IllegalArgumentException] {
+      DiffieHellmanTupleProverInput.create(BigInt(10).bigInteger, ProveDHTuple(g, g_y, g_x, g_xy))
+    }
 
   }
 

--- a/sc/shared/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
@@ -168,7 +168,7 @@ class MixExampleSpecification extends CompilerTestingCommons
 
     // bob (2nd player) is generating a proof and it is passing verification
     // To Do: Extract below g_x from halfMixOutput
-    val dhtBob = DiffieHellmanTupleProverInput(y, ProveDHTuple(g, gX, gY, gXY))
+    val dhtBob = DiffieHellmanTupleProverInput.create(y, ProveDHTuple(g, gX, gY, gXY))
 
     val proofFullMix = (new ContextEnrichingTestProvingInterpreter).withDHSecrets(
       Seq(dhtBob)
@@ -222,7 +222,7 @@ class MixExampleSpecification extends CompilerTestingCommons
     )
 
     // To Do: Extract below g_y, g_xy from fullMixOutputs registers
-    val dhtAlice = DiffieHellmanTupleProverInput(x, ProveDHTuple(g, gY, gX, gXY))
+    val dhtAlice = DiffieHellmanTupleProverInput.create(x, ProveDHTuple(g, gY, gX, gXY))
 
     val proofAliceSpend = (new ContextEnrichingTestProvingInterpreter).withDHSecrets(
       Seq(dhtAlice)

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/JavaHelpers.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/JavaHelpers.scala
@@ -476,7 +476,7 @@ object JavaHelpers {
       v: EcPointType,
       x: BigInteger): DiffieHellmanTupleProverInput = {
     val dht = ProveDHTuple(g, h, u, v)
-    DiffieHellmanTupleProverInput(x, dht)
+    DiffieHellmanTupleProverInput.create(x, dht)
   }
 }
 


### PR DESCRIPTION
Closes #638 

Note: Originally I wanted to make the case-class primary constructor private. On 2.12/2.13 this worked fine, but there's bug in 2.11. Maybe it would be good time to reconsider dropping of old unsupported 2.11.x?