### PR TITLE
Add compiler-level box verification util functions (closes #1037)

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -2,7 +2,7 @@ package sigma.ast
 
 import org.ergoplatform.ErgoAddressEncoder.NetworkPrefix
 import org.ergoplatform.{ErgoAddressEncoder, P2PKAddress}
-import org.ergoplatform.ErgoBox.RegisterId
+import org.ergoplatform.ErgoBox.{R4, R5, R6, R7, R8, R9, RegisterId}
 import scorex.util.encode.{Base16, Base58, Base64}
 import sigma.data._
 import sigma.{Colls}
@@ -529,11 +529,19 @@ object SigmaPredef {
         Seq(ArgInfo("id", "identifier of the register")))
     )
 
+    /** Element type of the `tokens` collection of a box: (tokenId, amount). */
+    private val STokenElemType: SType = org.ergoplatform.ErgoBox.STokenType
+
+    /** Builds `box.tokens` as a typed collection of (Coll[Byte], Long) tuples. */
+    private def boxTokens(box: Value[SBox.type]): Value[SCollection[STuple]] =
+      mkMethodCall(box, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty).asCollection[STuple]
+
     /** Checks that two boxes have equal monetary value and equal guarding script. */
     val VerifySameForBasicRequiredRegistersFunc = PredefinedFunc("verifySameForBasicRequiredRegisters",
       Lambda(Array("inBox" -> SBox, "outBox" -> SBox), SBoolean, None),
       PredefFuncInfo(
-        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked)) =>
+        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked))
+            if inBox.tpe == SBox && outBox.tpe == SBox =>
           mkBinAnd(
             mkEQ(mkExtractAmount(inBox), mkExtractAmount(outBox)),
             mkEQ(mkExtractScriptBytes(inBox), mkExtractScriptBytes(outBox))
@@ -550,15 +558,14 @@ object SigmaPredef {
     val VerifySameForRequiredRegistersFunc = PredefinedFunc("verifySameForRequiredRegisters",
       Lambda(Array("inBox" -> SBox, "outBox" -> SBox), SBoolean, None),
       PredefFuncInfo(
-        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked)) =>
-          val tokensIn = mkMethodCall(inBox, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty)
-          val tokensOut = mkMethodCall(outBox, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty)
+        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked))
+            if inBox.tpe == SBox && outBox.tpe == SBox =>
           mkBinAnd(
             mkBinAnd(
               mkEQ(mkExtractAmount(inBox), mkExtractAmount(outBox)),
               mkEQ(mkExtractScriptBytes(inBox), mkExtractScriptBytes(outBox))
             ),
-            mkEQ(tokensIn, tokensOut)
+            mkEQ(boxTokens(inBox), boxTokens(outBox))
           )
         }),
       OperationInfo(MethodCall,
@@ -573,18 +580,14 @@ object SigmaPredef {
     val VerifyUsedAdditionalRegistersFunc = PredefinedFunc("verifyUsedAdditionalRegisters",
       Lambda(Array("box" -> SBox, "used" -> SInt), SBoolean, None),
       PredefFuncInfo(
-        { case (_, Seq(box: Value[SBox.type]@unchecked, used: Value[SInt.type]@unchecked)) =>
+        { case (_, Seq(box: Value[SBox.type]@unchecked, used: Value[SInt.type]@unchecked))
+            if box.tpe == SBox && used.tpe == SInt =>
           def regIsEmpty(reg: RegisterId): BoolValue =
             mkLogicalNot(mkOptionIsDefined(
               mkExtractRegisterAs(box, reg, SOption(SAny)).asValue[SOption[SAny.type]]))
           // (used >= n || box.R{n+3}[Any].isEmpty) for n = 1..6 (registers R4..R9)
           val clauses: Seq[BoolValue] = Seq[(Int, RegisterId)](
-            1 -> org.ergoplatform.ErgoBox.R4,
-            2 -> org.ergoplatform.ErgoBox.R5,
-            3 -> org.ergoplatform.ErgoBox.R6,
-            4 -> org.ergoplatform.ErgoBox.R7,
-            5 -> org.ergoplatform.ErgoBox.R8,
-            6 -> org.ergoplatform.ErgoBox.R9
+            1 -> R4, 2 -> R5, 3 -> R6, 4 -> R7, 5 -> R8, 6 -> R9
           ).map { case (n, reg) => mkBinOr(mkGE(used, IntConstant(n)), regIsEmpty(reg)) }
           clauses.reduce[BoolValue](mkBinAnd)
         }),
@@ -592,27 +595,21 @@ object SigmaPredef {
         """Returns \lst{true} if \lst{box} uses only the first \lst{used} non-mandatory registers,
           | i.e. all registers with index greater than \lst{used} (counting R4 as 1, ..., R9 as 6)
           | are empty.
-          | NOTE: when a register beyond the first \lst{used} ones is defined, the emptiness check
-          | \lst{R{i}[Any].isEmpty} fails with an exception (instead of returning \lst{false}),
-          | so the script evaluation fails, which is the desired behavior when the function is
-          | used as a guarding predicate of a box.
+          | NOTE: when a register beyond the first \lst{used} ones is defined, checking that the
+          | register is empty (\lst{isEmpty} of the register read as \lst{Option[Any]}) fails with
+          | an exception instead of returning \lst{false}, so the script evaluation fails, which is
+          | the desired behavior when the function is used as a guarding predicate of a box.
         """.stripMargin,
         Seq(ArgInfo("box", "the box to check"),
             ArgInfo("used", "number of additional registers (R4..R9) allowed to be used")))
     )
 
-    /** Element type of the `tokens` collection of a box: (tokenId, amount). */
-    private val STokenElemType: SType = org.ergoplatform.ErgoBox.STokenType
-
-    /** Builds `box.tokens` as a typed collection of (Coll[Byte], Long) tuples. */
-    private def boxTokens(box: Value[SBox.type]): Value[SCollection[STuple]] =
-      mkMethodCall(box, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty).asCollection[STuple]
-
     /** Checks that a box contains at least one unit of the given token. */
     val VerifyBoxHasMarkerTokenFunc = PredefinedFunc("verifyBoxHasMarkerToken",
       Lambda(Array("box" -> SBox, "token" -> SByteArray), SBoolean, None),
       PredefFuncInfo(
-        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked)) =>
+        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked))
+            if box.tpe == SBox && token.tpe == SByteArray =>
           val t = Ident("$t", STokenElemType).asValue[STuple]
           // t._1 == token && t._2 >= 1L
           val body = mkBinAnd(
@@ -631,7 +628,8 @@ object SigmaPredef {
     val VerifyBoxHasNoMarkerTokenFunc = PredefinedFunc("verifyBoxHasNoMarkerToken",
       Lambda(Array("box" -> SBox, "token" -> SByteArray), SBoolean, None),
       PredefFuncInfo(
-        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked)) =>
+        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked))
+            if box.tpe == SBox && token.tpe == SByteArray =>
           val t = Ident("$t", STokenElemType).asValue[STuple]
           // t._1 != token
           val body = mkNEQ(mkSelectField(t, 1.toByte).asValue[SByteArray], token)
@@ -648,7 +646,8 @@ object SigmaPredef {
       Lambda(Array("inBox" -> SBox, "outBox" -> SBox, "token" -> SByteArray, "amount" -> SLong), SBoolean, None),
       PredefFuncInfo(
         { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked,
-                       token: Value[SByteArray]@unchecked, amount: Value[SLong.type]@unchecked)) =>
+                       token: Value[SByteArray]@unchecked, amount: Value[SLong.type]@unchecked))
+            if inBox.tpe == SBox && outBox.tpe == SBox && token.tpe == SByteArray && amount.tpe == SLong =>
           val it = Ident("$it", STokenElemType).asValue[STuple]
           val itId = mkSelectField(it, 1.toByte).asValue[SByteArray]
           val itAmount = mkSelectField(it, 2.toByte).asValue[SLong.type]
@@ -670,18 +669,19 @@ object SigmaPredef {
         """Returns \lst{true} if every token of \lst{inBox} is preserved in \lst{outBox}, except for
           | the token with id \lst{token} whose amount in \lst{outBox} must be exactly \lst{amount} less
           | than in \lst{inBox}.
+          | NOTE: the check is a \lst{forall} over the tokens of \lst{inBox}, hence it is vacuously
+          | \lst{true} when \lst{inBox} does not hold \lst{token} at all (nothing is spent).
+          | NOTE: spending the token in full (down to zero, i.e. \lst{token} absent in \lst{outBox})
+          | returns \lst{false}: the function requires \lst{outBox} to still hold the token.
+          | NOTE: the amount comparison uses checked arithmetic (\lst{outAmount + amount}), so if the
+          | sum overflows \lst{Long} the evaluation fails with an exception instead of returning
+          | \lst{false}.
         """.stripMargin,
         Seq(ArgInfo("inBox", "the input box"), ArgInfo("outBox", "the output box"),
             ArgInfo("token", "the token id being spent"), ArgInfo("amount", "the spent amount")))
     )
 
     val globalFuncs: Map[String, PredefinedFunc] = Seq(
-      VerifySameForBasicRequiredRegistersFunc,
-      VerifySameForRequiredRegistersFunc,
-      VerifyUsedAdditionalRegistersFunc,
-      VerifyBoxHasMarkerTokenFunc,
-      VerifyBoxHasNoMarkerTokenFunc,
-      VerifySpentTokenFunc,
       AllOfFunc,
       AnyOfFunc,
       XorOfFunc,
@@ -714,7 +714,13 @@ object SigmaPredef {
       SerializeFunc,
       DeserializeToFunc,
       GetVarFromInputFunc,
-      FromBigEndianBytesFunc
+      FromBigEndianBytesFunc,
+      VerifySameForBasicRequiredRegistersFunc,
+      VerifySameForRequiredRegistersFunc,
+      VerifyUsedAdditionalRegistersFunc,
+      VerifyBoxHasMarkerTokenFunc,
+      VerifyBoxHasNoMarkerTokenFunc,
+      VerifySpentTokenFunc
     ).map(f => f.name -> f).toMap
 
     def comparisonOp(symbolName: String, opDesc: ValueCompanion, desc: String, args: Seq[ArgInfo]) = {

--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -529,7 +529,159 @@ object SigmaPredef {
         Seq(ArgInfo("id", "identifier of the register")))
     )
 
+    /** Checks that two boxes have equal monetary value and equal guarding script. */
+    val VerifySameForBasicRequiredRegistersFunc = PredefinedFunc("verifySameForBasicRequiredRegisters",
+      Lambda(Array("inBox" -> SBox, "outBox" -> SBox), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked)) =>
+          mkBinAnd(
+            mkEQ(mkExtractAmount(inBox), mkExtractAmount(outBox)),
+            mkEQ(mkExtractScriptBytes(inBox), mkExtractScriptBytes(outBox))
+          )
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if \lst{inBox} and \lst{outBox} have the same monetary value
+          | (\lst{value}) and the same guarding script (\lst{propositionBytes}).
+        """.stripMargin,
+        Seq(ArgInfo("inBox", "the first box"), ArgInfo("outBox", "the second box")))
+    )
+
+    /** Same as [[VerifySameForBasicRequiredRegistersFunc]] but additionally requires equal tokens. */
+    val VerifySameForRequiredRegistersFunc = PredefinedFunc("verifySameForRequiredRegisters",
+      Lambda(Array("inBox" -> SBox, "outBox" -> SBox), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked)) =>
+          val tokensIn = mkMethodCall(inBox, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty)
+          val tokensOut = mkMethodCall(outBox, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty)
+          mkBinAnd(
+            mkBinAnd(
+              mkEQ(mkExtractAmount(inBox), mkExtractAmount(outBox)),
+              mkEQ(mkExtractScriptBytes(inBox), mkExtractScriptBytes(outBox))
+            ),
+            mkEQ(tokensIn, tokensOut)
+          )
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if \lst{inBox} and \lst{outBox} have the same monetary value
+          | (\lst{value}), the same guarding script (\lst{propositionBytes}) and the same
+          | secondary \lst{tokens}.
+        """.stripMargin,
+        Seq(ArgInfo("inBox", "the first box"), ArgInfo("outBox", "the second box")))
+    )
+
+    /** Checks that a box does not use any non-mandatory register beyond the first \lst{used} ones. */
+    val VerifyUsedAdditionalRegistersFunc = PredefinedFunc("verifyUsedAdditionalRegisters",
+      Lambda(Array("box" -> SBox, "used" -> SInt), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(box: Value[SBox.type]@unchecked, used: Value[SInt.type]@unchecked)) =>
+          def regIsEmpty(reg: RegisterId): BoolValue =
+            mkLogicalNot(mkOptionIsDefined(
+              mkExtractRegisterAs(box, reg, SOption(SAny)).asValue[SOption[SAny.type]]))
+          // (used >= n || box.R{n+3}[Any].isEmpty) for n = 1..6 (registers R4..R9)
+          val clauses: Seq[BoolValue] = Seq[(Int, RegisterId)](
+            1 -> org.ergoplatform.ErgoBox.R4,
+            2 -> org.ergoplatform.ErgoBox.R5,
+            3 -> org.ergoplatform.ErgoBox.R6,
+            4 -> org.ergoplatform.ErgoBox.R7,
+            5 -> org.ergoplatform.ErgoBox.R8,
+            6 -> org.ergoplatform.ErgoBox.R9
+          ).map { case (n, reg) => mkBinOr(mkGE(used, IntConstant(n)), regIsEmpty(reg)) }
+          clauses.reduce[BoolValue](mkBinAnd)
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if \lst{box} uses only the first \lst{used} non-mandatory registers,
+          | i.e. all registers with index greater than \lst{used} (counting R4 as 1, ..., R9 as 6)
+          | are empty.
+          | NOTE: when a register beyond the first \lst{used} ones is defined, the emptiness check
+          | \lst{R{i}[Any].isEmpty} fails with an exception (instead of returning \lst{false}),
+          | so the script evaluation fails, which is the desired behavior when the function is
+          | used as a guarding predicate of a box.
+        """.stripMargin,
+        Seq(ArgInfo("box", "the box to check"),
+            ArgInfo("used", "number of additional registers (R4..R9) allowed to be used")))
+    )
+
+    /** Element type of the `tokens` collection of a box: (tokenId, amount). */
+    private val STokenElemType: SType = org.ergoplatform.ErgoBox.STokenType
+
+    /** Builds `box.tokens` as a typed collection of (Coll[Byte], Long) tuples. */
+    private def boxTokens(box: Value[SBox.type]): Value[SCollection[STuple]] =
+      mkMethodCall(box, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty).asCollection[STuple]
+
+    /** Checks that a box contains at least one unit of the given token. */
+    val VerifyBoxHasMarkerTokenFunc = PredefinedFunc("verifyBoxHasMarkerToken",
+      Lambda(Array("box" -> SBox, "token" -> SByteArray), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked)) =>
+          val t = Ident("$t", STokenElemType).asValue[STuple]
+          // t._1 == token && t._2 >= 1L
+          val body = mkBinAnd(
+            mkEQ(mkSelectField(t, 1.toByte).asValue[SByteArray], token),
+            mkGE(mkSelectField(t, 2.toByte).asValue[SLong.type], LongConstant(1L))
+          )
+          val lam = mkLambda(Array[(String, SType)]("$t" -> STokenElemType), SBoolean, Some(body))
+          mkExists(boxTokens(box), lam)
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if \lst{box} holds at least one unit of the token with id \lst{token}.""",
+        Seq(ArgInfo("box", "the box to check"), ArgInfo("token", "the token id (\\lst{Coll[Byte]})")))
+    )
+
+    /** Checks that a box does not contain the given token. */
+    val VerifyBoxHasNoMarkerTokenFunc = PredefinedFunc("verifyBoxHasNoMarkerToken",
+      Lambda(Array("box" -> SBox, "token" -> SByteArray), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(box: Value[SBox.type]@unchecked, token: Value[SByteArray]@unchecked)) =>
+          val t = Ident("$t", STokenElemType).asValue[STuple]
+          // t._1 != token
+          val body = mkNEQ(mkSelectField(t, 1.toByte).asValue[SByteArray], token)
+          val lam = mkLambda(Array[(String, SType)]("$t" -> STokenElemType), SBoolean, Some(body))
+          mkForAll(boxTokens(box), lam)
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if \lst{box} does not hold the token with id \lst{token}.""",
+        Seq(ArgInfo("box", "the box to check"), ArgInfo("token", "the token id (\\lst{Coll[Byte]})")))
+    )
+
+    /** Checks that the given token is spent from \lst{inBox} to \lst{outBox} by exactly \lst{amount}. */
+    val VerifySpentTokenFunc = PredefinedFunc("verifySpentToken",
+      Lambda(Array("inBox" -> SBox, "outBox" -> SBox, "token" -> SByteArray, "amount" -> SLong), SBoolean, None),
+      PredefFuncInfo(
+        { case (_, Seq(inBox: Value[SBox.type]@unchecked, outBox: Value[SBox.type]@unchecked,
+                       token: Value[SByteArray]@unchecked, amount: Value[SLong.type]@unchecked)) =>
+          val it = Ident("$it", STokenElemType).asValue[STuple]
+          val itId = mkSelectField(it, 1.toByte).asValue[SByteArray]
+          val itAmount = mkSelectField(it, 2.toByte).asValue[SLong.type]
+          // builds: outBox.tokens.exists(ot => it._1 == ot._1 && it._2 == ot._2 [+ amount])
+          def existsInOut(addAmount: Boolean): Value[SBoolean.type] = {
+            val ot = Ident("$ot", STokenElemType).asValue[STuple]
+            val otId = mkSelectField(ot, 1.toByte).asValue[SByteArray]
+            val otAmount = mkSelectField(ot, 2.toByte).asValue[SLong.type]
+            val rhs = if (addAmount) mkPlus(otAmount, amount) else otAmount
+            val body = mkBinAnd(mkEQ(itId, otId), mkEQ(itAmount, rhs))
+            mkExists(boxTokens(outBox), mkLambda(Array[(String, SType)]("$ot" -> STokenElemType), SBoolean, Some(body)))
+          }
+          // if (it._1 == token) <spent> else <unchanged>
+          val ifBody = mkIf(mkEQ(itId, token), existsInOut(addAmount = true), existsInOut(addAmount = false))
+          val outerLam = mkLambda(Array[(String, SType)]("$it" -> STokenElemType), SBoolean, Some(ifBody))
+          mkForAll(boxTokens(inBox), outerLam)
+        }),
+      OperationInfo(MethodCall,
+        """Returns \lst{true} if every token of \lst{inBox} is preserved in \lst{outBox}, except for
+          | the token with id \lst{token} whose amount in \lst{outBox} must be exactly \lst{amount} less
+          | than in \lst{inBox}.
+        """.stripMargin,
+        Seq(ArgInfo("inBox", "the input box"), ArgInfo("outBox", "the output box"),
+            ArgInfo("token", "the token id being spent"), ArgInfo("amount", "the spent amount")))
+    )
+
     val globalFuncs: Map[String, PredefinedFunc] = Seq(
+      VerifySameForBasicRequiredRegistersFunc,
+      VerifySameForRequiredRegistersFunc,
+      VerifyUsedAdditionalRegistersFunc,
+      VerifyBoxHasMarkerTokenFunc,
+      VerifyBoxHasNoMarkerTokenFunc,
+      VerifySpentTokenFunc,
       AllOfFunc,
       AnyOfFunc,
       XorOfFunc,

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -1331,7 +1331,53 @@ def executeFromSelfRegWithDefault[T](id: Int, default: T): T
   *         replaced and all other bytes remain exactly the same
   */
 def substConstants[T](scriptBytes: Coll[Byte], positions: Coll[Int], newValues: Coll[T]): Coll[Byte]
+
+/** Returns true if `inBox` and `outBox` have the same monetary value (`value`)
+ * and the same guarding script (`propositionBytes`).
+ * Compiler-level utility: it is expanded at compile time into existing ErgoTree
+ * operations, so no new ErgoTree node is involved (the same holds for all the
+ * `verify*` functions below).
+ */
+def verifySameForBasicRequiredRegisters(inBox: Box, outBox: Box): Boolean
+
+/** Returns true if `inBox` and `outBox` have the same monetary value (`value`),
+ * the same guarding script (`propositionBytes`) and the same secondary `tokens`.
+ */
+def verifySameForRequiredRegisters(inBox: Box, outBox: Box): Boolean
+
+/** Returns true if `box` uses only the first `used` non-mandatory registers,
+ * i.e. all registers with index greater than `used` (counting R4 as 1, ..., R9 as 6)
+ * are empty.
+ * NOTE: when a register beyond the first `used` ones is defined, checking that the
+ * register is empty (`isEmpty` of the register read as `Option[Any]`) fails with an
+ * exception instead of returning false, so the script evaluation fails, which is the
+ * desired behavior when the function is used as a guarding predicate of a box.
+ */
+def verifyUsedAdditionalRegisters(box: Box, used: Int): Boolean
+
+/** Returns true if `box` holds at least one unit of the token with id `token`. */
+def verifyBoxHasMarkerToken(box: Box, token: Coll[Byte]): Boolean
+
+/** Returns true if `box` does not hold the token with id `token`. */
+def verifyBoxHasNoMarkerToken(box: Box, token: Coll[Byte]): Boolean
+
+/** Returns true if every token of `inBox` is preserved in `outBox`, except for the
+ * token with id `token` whose amount in `outBox` must be exactly `amount` less than
+ * in `inBox`.
+ * NOTE: the check is a `forall` over the tokens of `inBox`, hence it is vacuously
+ * true when `inBox` does not hold `token` at all (nothing is spent).
+ * NOTE: spending the token in full (down to zero, i.e. `token` absent in `outBox`)
+ * returns false: the function requires `outBox` to still hold the token.
+ * NOTE: the amount comparison uses checked arithmetic (`outAmount + amount`), so if
+ * the sum overflows `Long` the evaluation fails with an exception instead of
+ * returning false.
+ */
+def verifySpentToken(inBox: Box, outBox: Box, token: Coll[Byte], amount: Long): Boolean
 ```
+
+The names of the predefined functions are reserved: a script that declares a `val` or a
+`def` with the name of a predefined function (e.g. `def verifySpentToken(...)`) is rejected
+by the compiler with a `Variable ... already defined` error.
 
 ## Known Limitations
 

--- a/sc/shared/src/test/scala/sigmastate/utxo/UtilFunctionsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/UtilFunctionsSpecification.scala
@@ -7,6 +7,7 @@ import sigma.Colls
 import sigma.ast._
 import sigma.ast.syntax._
 import sigma.data.{AvlTreeData, Digest32Coll}
+import sigma.exceptions.TyperException
 import sigma.interpreter.{ContextExtension, ProverResult}
 import sigmastate.CompilerCrossVersionProps
 import sigmastate.helpers.TestingHelpers._
@@ -134,9 +135,10 @@ class UtilFunctionsSpecification extends CompilerTestingCommons with CompilerCro
   }
 
   property("verifyUsedAdditionalRegisters - register beyond the allowed ones") {
-    // NOTE: when a register beyond the first `used` ones is defined, the emptiness
-    // check `R{i}[Any].isEmpty` throws (rather than returning false), so the spending
-    // attempt fails, which is the desired guarding behavior.
+    // NOTE: when a register beyond the first `used` ones is defined, checking that the
+    // register is empty (`isEmpty` of the register read as `Option[Any]`) throws rather
+    // than returning false, so the spending attempt fails, which is the desired
+    // guarding behavior.
     testEval("sigmaProp(verifyUsedAdditionalRegisters(SELF, 1))",
       selfRegisters = Map(R4 -> IntConstant(7), R5 -> LongConstant(1L)),
       expectSuccess = false)
@@ -200,5 +202,54 @@ class UtilFunctionsSpecification extends CompilerTestingCommons with CompilerCro
     testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 100L) == false)""",
       selfTokens = Seq(token1 -> 100L),
       outTokens = ArraySeq.empty)
+  }
+
+  property("verifySpentToken - inBox without the token is vacuously true") {
+    // the check is a `forall` over the tokens of `inBox`: when `inBox` does not hold
+    // `token` at all there is nothing to spend and the function returns true (pinned
+    // here so that the semantics is asserted rather than implicit)
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 40L))""",
+      selfTokens = Seq(token2 -> 7L),
+      outTokens = Seq(token2 -> 7L))
+  }
+
+  property("verifySpentToken - inBox without any token is vacuously true") {
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 40L))""")
+  }
+
+  // name reservation
+
+  private val utilFunctionNames = Seq(
+    "verifySameForBasicRequiredRegisters", "verifySameForRequiredRegisters",
+    "verifyUsedAdditionalRegisters", "verifyBoxHasMarkerToken",
+    "verifyBoxHasNoMarkerToken", "verifySpentToken")
+
+  property("util function names cannot be redefined by user scripts (same signature)") {
+    // the typer seeds its environment with the predefined function names, so a
+    // user-defined function with the same name is rejected before any expansion can
+    // silently replace it
+    val script =
+      s"""{
+        |  def verifyBoxHasMarkerToken(box: Box, token: Coll[Byte]): Boolean = false
+        |  sigmaProp(verifyBoxHasMarkerToken(SELF, fromBase16("${tokenHex(1)}")))
+        |}""".stripMargin
+    val e = the[TyperException] thrownBy compile(emptyEnv, script)
+    e.getMessage should include("already defined")
+  }
+
+  property("util function names cannot be redefined by user scripts (any signature)") {
+    utilFunctionNames.foreach { name =>
+      val script = s"{ def $name(x: Int): Int = x; sigmaProp($name(1) == 1) }"
+      val e = the[TyperException] thrownBy compile(emptyEnv, script)
+      e.getMessage should include(s"Variable $name already defined")
+    }
+  }
+
+  property("util function names cannot be rebound by val in user scripts") {
+    utilFunctionNames.foreach { name =>
+      val script = s"{ val $name = 1; sigmaProp($name == 1) }"
+      val e = the[TyperException] thrownBy compile(emptyEnv, script)
+      e.getMessage should include(s"Variable $name already defined")
+    }
   }
 }

--- a/sc/shared/src/test/scala/sigmastate/utxo/UtilFunctionsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/UtilFunctionsSpecification.scala
@@ -1,0 +1,204 @@
+package sigmastate.utxo
+
+import org.ergoplatform.ErgoBox.{AdditionalRegisters, R4, R5, Token}
+import org.ergoplatform.{ErgoLikeTransaction, Input}
+import scorex.util.encode.Base16
+import sigma.Colls
+import sigma.ast._
+import sigma.ast.syntax._
+import sigma.data.{AvlTreeData, Digest32Coll}
+import sigma.interpreter.{ContextExtension, ProverResult}
+import sigmastate.CompilerCrossVersionProps
+import sigmastate.helpers.TestingHelpers._
+import sigmastate.helpers.{CompilerTestingCommons, ContextEnrichingTestProvingInterpreter, ErgoLikeContextTesting, ErgoLikeTestInterpreter}
+import sigmastate.interpreter.Interpreter.emptyEnv
+import sigmastate.utils.Helpers._
+
+import scala.collection.compat.immutable.ArraySeq
+
+/** Specification of the global utility functions for common box verification patterns
+  * (see https://github.com/ergoplatform/sigmastate-interpreter/issues/1037):
+  * verifySameForBasicRequiredRegisters, verifySameForRequiredRegisters,
+  * verifyUsedAdditionalRegisters, verifyBoxHasMarkerToken, verifyBoxHasNoMarkerToken,
+  * verifySpentToken.
+  *
+  * These functions are compiler-level (frontend) utilities, i.e. they are expanded
+  * during compilation into ErgoTree nodes already supported by the interpreter, so no
+  * changes of the consensus-critical ErgoTree level are involved.
+  */
+class UtilFunctionsSpecification extends CompilerTestingCommons with CompilerCrossVersionProps {
+  override val printVersions: Boolean = false
+  implicit lazy val IR: TestingIRContext = new TestingIRContext
+
+  private def tokenBytes(b: Byte): Array[Byte] = Array.fill(32)(b)
+  private def mkToken(b: Byte): Digest32Coll = Digest32Coll @@ Colls.fromArray(tokenBytes(b))
+  private def tokenHex(b: Byte): String = Base16.encode(tokenBytes(b))
+
+  private val token1: Digest32Coll = mkToken(1)
+  private val token2: Digest32Coll = mkToken(2)
+
+  /** Compiles `script` to an ErgoTree guarding the spent box (`SELF`), builds a spending
+    * transaction with a single output box (`OUTPUTS(0)`) and checks the result:
+    * if `expectSuccess` the proposition must prove and verify, otherwise proving must fail
+    * (which happens both when the proposition evaluates to `false` and when its evaluation
+    * throws an exception).
+    */
+  private def testEval(
+      script: String,
+      selfValue: Long = 10,
+      selfTokens: Seq[Token] = ArraySeq.empty,
+      selfRegisters: AdditionalRegisters = Map.empty,
+      outValue: Long = 10,
+      outTokens: Seq[Token] = ArraySeq.empty,
+      outRegisters: AdditionalRegisters = Map.empty,
+      outSameScript: Boolean = true,
+      expectSuccess: Boolean = true): Unit = {
+    val prop = compile(emptyEnv, script).asBoolValue.toSigmaProp
+    val tree = mkTestErgoTree(prop)
+    val outTree = if (outSameScript) tree else TrueTree
+
+    val boxToSpend = testBox(selfValue, tree, creationHeight = 5,
+      additionalTokens = selfTokens, additionalRegisters = selfRegisters)
+    val newBox = testBox(outValue, outTree, creationHeight = 0,
+      additionalTokens = outTokens, additionalRegisters = outRegisters)
+    val tx = new ErgoLikeTransaction(
+      IndexedSeq(Input(boxToSpend.id, ProverResult(Array.emptyByteArray, ContextExtension.empty))),
+      ArraySeq.empty,
+      IndexedSeq(newBox))
+    val ctx = ErgoLikeContextTesting(currentHeight = 0,
+      lastBlockUtxoRoot = AvlTreeData.dummy, ErgoLikeContextTesting.dummyPubkey,
+      boxesToSpend = IndexedSeq(boxToSpend),
+      spendingTransaction = tx, self = boxToSpend, ergoTreeVersionInTests)
+
+    val prover = new ContextEnrichingTestProvingInterpreter()
+    val res = prover.prove(emptyEnv, tree, ctx, fakeMessage)
+    if (expectSuccess) {
+      val pr = res.getOrThrow
+      val verifier = new ErgoLikeTestInterpreter
+      verifier.verify(emptyEnv, tree, ctx.withExtension(pr.extension), pr.proof, fakeMessage)
+        .getOrThrow._1 shouldBe true
+    } else {
+      res.isFailure shouldBe true
+    }
+  }
+
+  // verifySameForBasicRequiredRegisters
+
+  property("verifySameForBasicRequiredRegisters - same value and script") {
+    testEval("sigmaProp(verifySameForBasicRequiredRegisters(SELF, OUTPUTS(0)))")
+  }
+
+  property("verifySameForBasicRequiredRegisters - different value") {
+    testEval("sigmaProp(verifySameForBasicRequiredRegisters(SELF, OUTPUTS(0)) == false)",
+      outValue = 20)
+  }
+
+  property("verifySameForBasicRequiredRegisters - different script") {
+    testEval("sigmaProp(verifySameForBasicRequiredRegisters(SELF, OUTPUTS(0)) == false)",
+      outSameScript = false)
+  }
+
+  // verifySameForRequiredRegisters
+
+  property("verifySameForRequiredRegisters - same value, script and tokens") {
+    testEval("sigmaProp(verifySameForRequiredRegisters(SELF, OUTPUTS(0)))",
+      selfTokens = Seq(token1 -> 100L, token2 -> 1L),
+      outTokens = Seq(token1 -> 100L, token2 -> 1L))
+  }
+
+  property("verifySameForRequiredRegisters - different token amount") {
+    testEval("sigmaProp(verifySameForRequiredRegisters(SELF, OUTPUTS(0)) == false)",
+      selfTokens = Seq(token1 -> 100L),
+      outTokens = Seq(token1 -> 99L))
+  }
+
+  property("verifySameForRequiredRegisters - missing token") {
+    testEval("sigmaProp(verifySameForRequiredRegisters(SELF, OUTPUTS(0)) == false)",
+      selfTokens = Seq(token1 -> 100L))
+  }
+
+  // verifyUsedAdditionalRegisters
+
+  property("verifyUsedAdditionalRegisters - exactly the used registers") {
+    testEval("sigmaProp(verifyUsedAdditionalRegisters(SELF, 2))",
+      selfRegisters = Map(R4 -> IntConstant(7), R5 -> LongConstant(1L)))
+  }
+
+  property("verifyUsedAdditionalRegisters - no additional registers") {
+    testEval("sigmaProp(verifyUsedAdditionalRegisters(SELF, 0))")
+  }
+
+  property("verifyUsedAdditionalRegisters - fewer registers than allowed") {
+    testEval("sigmaProp(verifyUsedAdditionalRegisters(SELF, 6))",
+      selfRegisters = Map(R4 -> IntConstant(7)))
+  }
+
+  property("verifyUsedAdditionalRegisters - register beyond the allowed ones") {
+    // NOTE: when a register beyond the first `used` ones is defined, the emptiness
+    // check `R{i}[Any].isEmpty` throws (rather than returning false), so the spending
+    // attempt fails, which is the desired guarding behavior.
+    testEval("sigmaProp(verifyUsedAdditionalRegisters(SELF, 1))",
+      selfRegisters = Map(R4 -> IntConstant(7), R5 -> LongConstant(1L)),
+      expectSuccess = false)
+  }
+
+  // verifyBoxHasMarkerToken
+
+  property("verifyBoxHasMarkerToken - box with the marker token") {
+    testEval(s"""sigmaProp(verifyBoxHasMarkerToken(SELF, fromBase16("${tokenHex(1)}")))""",
+      selfTokens = Seq(token1 -> 5L))
+  }
+
+  property("verifyBoxHasMarkerToken - box without the marker token") {
+    testEval(s"""sigmaProp(verifyBoxHasMarkerToken(SELF, fromBase16("${tokenHex(2)}")) == false)""",
+      selfTokens = Seq(token1 -> 5L))
+  }
+
+  property("verifyBoxHasMarkerToken - box without tokens at all") {
+    testEval(s"""sigmaProp(verifyBoxHasMarkerToken(SELF, fromBase16("${tokenHex(1)}")) == false)""")
+  }
+
+  // verifyBoxHasNoMarkerToken
+
+  property("verifyBoxHasNoMarkerToken - box without the marker token") {
+    testEval(s"""sigmaProp(verifyBoxHasNoMarkerToken(SELF, fromBase16("${tokenHex(2)}")))""",
+      selfTokens = Seq(token1 -> 5L))
+  }
+
+  property("verifyBoxHasNoMarkerToken - box without tokens at all") {
+    testEval(s"""sigmaProp(verifyBoxHasNoMarkerToken(SELF, fromBase16("${tokenHex(1)}")))""")
+  }
+
+  property("verifyBoxHasNoMarkerToken - box with the marker token") {
+    testEval(s"""sigmaProp(verifyBoxHasNoMarkerToken(SELF, fromBase16("${tokenHex(1)}")) == false)""",
+      selfTokens = Seq(token1 -> 5L))
+  }
+
+  // verifySpentToken
+
+  property("verifySpentToken - token spent by exact amount, others preserved") {
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 40L))""",
+      selfTokens = Seq(token1 -> 100L, token2 -> 7L),
+      outTokens = Seq(token1 -> 60L, token2 -> 7L))
+  }
+
+  property("verifySpentToken - wrong spent amount") {
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 30L) == false)""",
+      selfTokens = Seq(token1 -> 100L),
+      outTokens = Seq(token1 -> 60L))
+  }
+
+  property("verifySpentToken - another token not preserved") {
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 40L) == false)""",
+      selfTokens = Seq(token1 -> 100L, token2 -> 7L),
+      outTokens = Seq(token1 -> 60L, token2 -> 6L))
+  }
+
+  property("verifySpentToken - token fully spent is not supported") {
+    // when the token is completely absent in the output box, `exists` returns false,
+    // so full spending (down to zero) makes the function return false by design
+    testEval(s"""sigmaProp(verifySpentToken(SELF, OUTPUTS(0), fromBase16("${tokenHex(1)}"), 100L) == false)""",
+      selfTokens = Seq(token1 -> 100L),
+      outTokens = ArraySeq.empty)
+  }
+}


### PR DESCRIPTION
# Add compiler-level utility functions for common box verification patterns

Closes #1037

## Summary

This PR adds the 6 utility functions proposed in #1037 as **predefined global functions of the ErgoScript frontend** (`SigmaPredef.scala`). Each function is expanded at compile time into ErgoTree nodes that are already supported by the interpreter, so **no changes to the consensus-critical ErgoTree level** (serializers, opcodes, evaluator, `SigmaDsl`) are involved — addressing the review feedback that led to closing #1086.

| Function | Expands to |
|---|---|
| `verifySameForBasicRequiredRegisters(inBox: Box, outBox: Box): Boolean` | `inBox.value == outBox.value && inBox.propositionBytes == outBox.propositionBytes` |
| `verifySameForRequiredRegisters(inBox: Box, outBox: Box): Boolean` | the above `&& inBox.tokens == outBox.tokens` |
| `verifyUsedAdditionalRegisters(box: Box, used: Int): Boolean` | `(used >= 1 \|\| box.R4[Any].isEmpty) && ... && (used >= 6 \|\| box.R9[Any].isEmpty)` |
| `verifyBoxHasMarkerToken(box: Box, token: Coll[Byte]): Boolean` | `box.tokens.exists { t => t._1 == token && t._2 >= 1L }` |
| `verifyBoxHasNoMarkerToken(box: Box, token: Coll[Byte]): Boolean` | `box.tokens.forall { t => t._1 != token }` |
| `verifySpentToken(inBox: Box, outBox: Box, token: Coll[Byte], amount: Long): Boolean` | `inBox.tokens.forall { it => if (it._1 == token) outBox.tokens.exists { ot => it._1 == ot._1 && it._2 == ot._2 + amount } else outBox.tokens.exists { ot => it._1 == ot._1 && it._2 == ot._2 } }` |

The semantics follow the reference implementations given in #1037 (uncurried argument lists are used, consistently with the other predefined global functions).

## Implementation notes

- All functions are registered in `globalFuncs` of `PredefinedFuncRegistry` and are expanded by the typer via the existing `PredefinedFuncApply` mechanism (`PredefFuncInfo.irBuilder`), like `allOf`, `xorOf`, etc.
- The produced trees only use existing operations (`EQ`, `BinAnd`/`BinOr` (lazy), `Exists`/`ForAll`, `ExtractAmount`, `ExtractScriptBytes`, `ExtractRegisterAs`, `MethodCall(Box.tokens)`, `SelectField`, `If`, `ArithOp.Plus`), so the resulting `ErgoTree` serializes and evaluates in all script versions.
- `verifyUsedAdditionalRegisters` — one behavioral caveat, documented in the function's `OperationInfo`: the emptiness check is expressed as `R{i}[Any].isEmpty` (as in the issue's reference code). When a register beyond the first `used` ones **is** defined, `Box.getReg[Any]` throws `InvalidType` instead of returning `Some(_)`, so the script evaluation **fails** rather than returning `false`. Used as a guarding predicate this is the desired outcome (the spending attempt is rejected), but the value cannot be negated/composed to recover from the failing branch. As far as I can tell, current ErgoTree has no type-agnostic "register is defined" primitive that could avoid this.
- `verifySpentToken` follows the reference semantics literally: it requires the remainder `ot._2 == it._2 - amount` to be present in the output box, therefore spending a token **completely** (down to zero) yields `false` by design (covered by a test).

## Testing

New `UtilFunctionsSpecification` (in `sc/shared/src/test/scala/sigmastate/utxo/`) with 20 properties run across script versions via `CompilerCrossVersionProps`. Each function is covered with positive and negative cases; every script is compiled, wrapped into an `ErgoTree`, proven and verified through `ContextEnrichingTestProvingInterpreter` / `ErgoLikeTestInterpreter` against a real spending context (`SELF` + `OUTPUTS(0)` with configurable values, tokens and registers). The ErgoTree serialization roundtrip is exercised implicitly by proving/verification.
