### PR TITLE
Wrap non-OOM VirtualMachineError into a checked CompilerException during typecheck in compiler

### DIFF
--- a/data/shared/src/main/scala/sigma/exceptions/CompilerExceptions.scala
+++ b/data/shared/src/main/scala/sigma/exceptions/CompilerExceptions.scala
@@ -7,9 +7,13 @@ import sigma.ast.SourceContext
   *
   * @param message the error message
   * @param source an optional source context with location information
+  * @param cause an optional underlying cause for the exception
   */
-class CompilerException(message: String, val source: Option[SourceContext] = None)
-    extends SigmaException(message, None) {
+class CompilerException(
+    message: String,
+    val source: Option[SourceContext] = None,
+    cause: Option[Throwable] = None
+) extends SigmaException(message, cause) {
 
   override def getMessage: String = source.map { srcCtx =>
     val lineNumberStrPrefix = s"line ${srcCtx.line}: "
@@ -22,28 +26,49 @@ class CompilerException(message: String, val source: Option[SourceContext] = Non
   *
   * @param message the error message
   * @param source an optional source context with location information
+  * @param cause an optional underlying cause for the exception
   */
-class BinderException(message: String, source: Option[SourceContext] = None)
-    extends CompilerException(message, source)
+class BinderException(
+    message: String,
+    source: Option[SourceContext] = None,
+    cause: Option[Throwable] = None
+) extends CompilerException(message, source, cause)
 
 /** Exception thrown during the type checking phase of the compiler.
   *
   * @param message the error message
   * @param source an optional source context with location information
+  * @param cause an optional underlying cause for the exception
   */
-class TyperException(message: String, source: Option[SourceContext] = None)
-    extends CompilerException(message, source)
+class TyperException(
+    message: String,
+    source: Option[SourceContext] = None,
+    cause: Option[Throwable] = None
+) extends CompilerException(message, source, cause)
 
 /** Exception thrown during the building phase of the compiler.
   *
   * @param message the error message
   * @param source an optional source context with location information
+  * @param cause an optional underlying cause for the exception
   */
-class BuilderException(message: String, source: Option[SourceContext] = None)
-  extends CompilerException(message, source)
+class BuilderException(
+    message: String,
+    source: Option[SourceContext] = None,
+    cause: Option[Throwable] = None
+) extends CompilerException(message, source, cause)
 
-class GraphBuildingException(message: String, source: Option[SourceContext])
-    extends CompilerException(message, source)
+/** Exception thrown during graph building.
+  *
+  * @param message the error message
+  * @param source an optional source context with location information
+  * @param cause an optional underlying cause for the exception
+  */
+class GraphBuildingException(
+    message: String,
+    source: Option[SourceContext] = None,
+    cause: Option[Throwable] = None
+) extends CompilerException(message, source, cause)
 
 
 

--- a/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
@@ -63,35 +63,24 @@ class SigmaCompiler private(settings: CompilerSettings) {
 
   /** Parses the given ErgoScript source code and produces expression tree. */
   def parse(x: String): SValue = {
-    SigmaParser(x) match {
-      case Success(v, _) => v
-      case f: Parsed.Failure =>
-        throw new ParserException(s"Syntax error: $f", Some(SourceContext.fromParserFailure(f)))
+    SigmaCompiler.checkStackOverflow(source = None) {
+      SigmaParser(x) match {
+        case Success(v, _) => v
+        case f: Parsed.Failure =>
+          throw new ParserException(s"Syntax error: $f", Some(SourceContext.fromParserFailure(f)))
+      }
     }
   }
 
   /** Typechecks the given parsed expression and assigns types for all sub-expressions. */
   def typecheck(env: ScriptEnv, parsed: SValue): Value[SType] = {
-    try {
+    SigmaCompiler.checkStackOverflow(parsed.sourceContext.toOption) {
       val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
       val binder = new SigmaBinder(env, builder, networkPrefix, predefinedFuncRegistry)
       val bound = binder.bind(parsed)
       val typeEnv = env.collect { case (k, v: SType) => k -> v }
       val typer = new SigmaTyper(builder, predefinedFuncRegistry, typeEnv, settings.lowerMethodCalls)
-      val typed = typer.typecheck(bound)
-      typed
-    } catch {
-      // Rethrow OutOfMemoryError: it is not safe to continue after the heap is exhausted.
-      case oom: OutOfMemoryError => throw oom
-      // Wrap a stack overflow into a checked CompilerException so that a
-      // malformed/pathological script results in a normal compilation error instead of
-      // a fatal runtime error. Note that on the JVM a stack overflow is signalled as a
-      // StackOverflowError (a VirtualMachineError), while on Scala.js it surfaces as a
-      // scala.scalajs.js.JavaScriptException wrapping a native RangeError.
-      case t: Throwable if SigmaCompiler.isStackOverflow(t) =>
-        throw new CompilerException(
-          s"Script compilation failed (stack overflow): script is too complex or recursive",
-          parsed.sourceContext.toOption)
+      typer.typecheck(bound)
     }
   }
 
@@ -109,14 +98,16 @@ class SigmaCompiler private(settings: CompilerSettings) {
 
   /** Compiles the given typed expression. */
   def compileTyped(env: ScriptEnv, typedExpr: SValue)(implicit IR: IRContext): CompilerResult[IR.type] = {
-    val placeholdersEnv = env
-        .collect { case (name, t: SType) => name -> t }
-        .zipWithIndex
-        .map { case ((name, t), index) => name -> ConstantPlaceholder(index, t) }
-        .toMap
-    val compiledGraph = IR.buildGraph(env ++ placeholdersEnv, typedExpr)
-    val compiledTree = IR.buildTree(compiledGraph)
-    CompilerResult(env, "<no source code>", compiledGraph, compiledTree)
+    SigmaCompiler.checkStackOverflow(typedExpr.sourceContext.toOption) {
+      val placeholdersEnv = env
+          .collect { case (name, t: SType) => name -> t }
+          .zipWithIndex
+          .map { case ((name, t), index) => name -> ConstantPlaceholder(index, t) }
+          .toMap
+      val compiledGraph = IR.buildGraph(env ++ placeholdersEnv, typedExpr)
+      val compiledTree = IR.buildTree(compiledGraph)
+      CompilerResult(env, "<no source code>", compiledGraph, compiledTree)
+    }
   }
 
   /** Compiles the given parsed contract source. */
@@ -173,25 +164,61 @@ object SigmaCompiler {
 
   /** Returns true if the given throwable represents a stack overflow.
     *
-    * On the JVM a stack overflow is signalled as a [[StackOverflowError]] (a
-    * [[VirtualMachineError]]). On Scala.js there is no StackOverflowError; instead the
-    * JavaScript engine throws a native `RangeError` ("Maximum call stack size exceeded"),
-    * which Scala.js wraps into a `scala.scalajs.js.JavaScriptException`. Since shared code
-    * cannot reference JS-only types, the JS case is detected by inspecting the exception
-    * class name and message.
+    * On the JVM a stack overflow is signalled as a [[StackOverflowError]]. On Scala.js
+    * there is no `StackOverflowError`; instead the JavaScript engine throws a native
+    * `RangeError` ("Maximum call stack size exceeded" / "too much recursion"), which
+    * Scala.js wraps into a `scala.scalajs.js.JavaScriptException`. Since shared code cannot
+    * reference JS-only types, the JS case is detected by inspecting the exception class name
+    * and message.
+    *
+    * The overload taking `isJVM` is package-private so tests can assert both platform
+    * predicates without running on the actual platform.
     */
-  private def isStackOverflow(t: Throwable): Boolean = {
-    if (Environment.current.isJVM)
-      t.isInstanceOf[VirtualMachineError] && !t.isInstanceOf[OutOfMemoryError]
+  private[sigma] def isStackOverflow(t: Throwable): Boolean =
+    isStackOverflow(t, Environment.current.isJVM)
+
+  private[sigma] def isStackOverflow(t: Throwable, isJVM: Boolean): Boolean = {
+    if (isJVM)
+      t.isInstanceOf[StackOverflowError]
     else {
       // Scala.js: detect the native RangeError wrapped in js.JavaScriptException.
       val className = t.getClass.getName
       val message = String.valueOf(t.getMessage)
       className.contains("JavaScriptException") &&
-        (message.contains("Maximum call stack size exceeded") ||
-          message.contains("call stack size exceeded") ||
-          message.contains("too much recursion") ||
-          message.contains("RangeError"))
+        (message.contains("call stack size exceeded") ||
+          message.contains("too much recursion"))
+    }
+  }
+
+  /** Creates a [[CompilerException]] for a stack-overflow condition, preserving the
+    * original throwable as its cause.
+    */
+  private[sigma] def compilerStackOverflowException(
+      source: Option[SourceContext],
+      cause: Throwable): CompilerException = {
+    new CompilerException(
+      "Script compilation failed (stack overflow): script is too complex or recursive",
+      source,
+      Some(cause))
+  }
+
+  /** Runs the given computation and converts a stack overflow into a recoverable
+    * [[CompilerException]] while rethrowing all unrelated throwables (including
+    * [[OutOfMemoryError]]) unchanged.
+    */
+  private def checkStackOverflow[A](source: Option[SourceContext])(body: => A): A = {
+    try {
+      body
+    } catch {
+      // Convert a stack overflow (JVM StackOverflowError or JS RangeError) into a checked
+      // CompilerException so that a malformed/pathological script results in a normal
+      // compilation error instead of a fatal runtime error.
+      case t: Throwable if isStackOverflow(t) =>
+        throw compilerStackOverflowException(source, t)
+      // Everything else (OutOfMemoryError, InternalError, UnknownError,
+      // InterruptedException, ordinary exceptions, etc.) is unrelated to recursion depth
+      // and must propagate unchanged.
+      case t: Throwable => throw t
     }
   }
 

--- a/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
@@ -15,6 +15,7 @@ import SCollectionMethods.{ExistsMethod, ForallMethod, MapMethod}
 import sigma.compiler.ir.{GraphIRReflection, IRContext}
 import sigma.compiler.phases.{SigmaBinder, SigmaTyper}
 import sigma.exceptions.CompilerException
+import sigma.Environment
 import sigmastate.InterpreterReflection
 import sigmastate.lang.SigmaParser
 
@@ -82,12 +83,14 @@ class SigmaCompiler private(settings: CompilerSettings) {
     } catch {
       // Rethrow OutOfMemoryError: it is not safe to continue after the heap is exhausted.
       case oom: OutOfMemoryError => throw oom
-      // Wrap StackOverflowError (and other non-OOM VirtualMachineErrors) into a checked
-      // CompilerException so that a malformed/pathological script results in a normal
-      // compilation error instead of a fatal JVM error.
-      case vme: VirtualMachineError =>
+      // Wrap a stack overflow into a checked CompilerException so that a
+      // malformed/pathological script results in a normal compilation error instead of
+      // a fatal runtime error. Note that on the JVM a stack overflow is signalled as a
+      // StackOverflowError (a VirtualMachineError), while on Scala.js it surfaces as a
+      // scala.scalajs.js.JavaScriptException wrapping a native RangeError.
+      case t: Throwable if SigmaCompiler.isStackOverflow(t) =>
         throw new CompilerException(
-          s"Script compilation failed (${vme.getClass.getSimpleName}): script is too complex or recursive",
+          s"Script compilation failed (stack overflow): script is too complex or recursive",
           parsed.sourceContext.toOption)
     }
   }
@@ -167,6 +170,30 @@ class SigmaCompiler private(settings: CompilerSettings) {
 object SigmaCompiler {
   /** Force initialization of reflection before any instance of SigmaCompiler is used. */
   val _ = (InterpreterReflection, GraphIRReflection)
+
+  /** Returns true if the given throwable represents a stack overflow.
+    *
+    * On the JVM a stack overflow is signalled as a [[StackOverflowError]] (a
+    * [[VirtualMachineError]]). On Scala.js there is no StackOverflowError; instead the
+    * JavaScript engine throws a native `RangeError` ("Maximum call stack size exceeded"),
+    * which Scala.js wraps into a `scala.scalajs.js.JavaScriptException`. Since shared code
+    * cannot reference JS-only types, the JS case is detected by inspecting the exception
+    * class name and message.
+    */
+  private def isStackOverflow(t: Throwable): Boolean = {
+    if (Environment.current.isJVM)
+      t.isInstanceOf[VirtualMachineError] && !t.isInstanceOf[OutOfMemoryError]
+    else {
+      // Scala.js: detect the native RangeError wrapped in js.JavaScriptException.
+      val className = t.getClass.getName
+      val message = String.valueOf(t.getMessage)
+      className.contains("JavaScriptException") &&
+        (message.contains("Maximum call stack size exceeded") ||
+          message.contains("call stack size exceeded") ||
+          message.contains("too much recursion") ||
+          message.contains("RangeError"))
+    }
+  }
 
   /** Constructs an instance for the given settings. */
   def apply(settings: CompilerSettings): SigmaCompiler =

--- a/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
@@ -14,6 +14,7 @@ import sigma.ast.syntax.SValue
 import SCollectionMethods.{ExistsMethod, ForallMethod, MapMethod}
 import sigma.compiler.ir.{GraphIRReflection, IRContext}
 import sigma.compiler.phases.{SigmaBinder, SigmaTyper}
+import sigma.exceptions.CompilerException
 import sigmastate.InterpreterReflection
 import sigmastate.lang.SigmaParser
 
@@ -70,13 +71,25 @@ class SigmaCompiler private(settings: CompilerSettings) {
 
   /** Typechecks the given parsed expression and assigns types for all sub-expressions. */
   def typecheck(env: ScriptEnv, parsed: SValue): Value[SType] = {
-    val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
-    val binder = new SigmaBinder(env, builder, networkPrefix, predefinedFuncRegistry)
-    val bound = binder.bind(parsed)
-    val typeEnv = env.collect { case (k, v: SType) => k -> v }
-    val typer = new SigmaTyper(builder, predefinedFuncRegistry, typeEnv, settings.lowerMethodCalls)
-    val typed = typer.typecheck(bound)
-    typed
+    try {
+      val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
+      val binder = new SigmaBinder(env, builder, networkPrefix, predefinedFuncRegistry)
+      val bound = binder.bind(parsed)
+      val typeEnv = env.collect { case (k, v: SType) => k -> v }
+      val typer = new SigmaTyper(builder, predefinedFuncRegistry, typeEnv, settings.lowerMethodCalls)
+      val typed = typer.typecheck(bound)
+      typed
+    } catch {
+      // Rethrow OutOfMemoryError: it is not safe to continue after the heap is exhausted.
+      case oom: OutOfMemoryError => throw oom
+      // Wrap StackOverflowError (and other non-OOM VirtualMachineErrors) into a checked
+      // CompilerException so that a malformed/pathological script results in a normal
+      // compilation error instead of a fatal JVM error.
+      case vme: VirtualMachineError =>
+        throw new CompilerException(
+          s"Script compilation failed (${vme.getClass.getSimpleName}): script is too complex or recursive",
+          parsed.sourceContext.toOption)
+    }
   }
 
   def typecheck(env: ScriptEnv, code: String): Value[SType] = {

--- a/sc/shared/src/test/scala/sigma/compiler/SigmaCompilerExceptionHandlingTest.scala
+++ b/sc/shared/src/test/scala/sigma/compiler/SigmaCompilerExceptionHandlingTest.scala
@@ -1,0 +1,45 @@
+package sigma.compiler
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class SigmaCompilerExceptionHandlingTest
+  extends AnyPropSpec
+    with ScalaCheckPropertyChecks
+    with Matchers {
+
+  // A locally-named class that mimics the Scala.js wrapper name, so the shared JVM test
+  // can exercise the string-based JS predicate without depending on scalajs-library.
+  class JavaScriptException(msg: String) extends RuntimeException(msg)
+
+  property("JVM StackOverflowError is detected") {
+    SigmaCompiler.isStackOverflow(new StackOverflowError, isJVM = true) shouldBe true
+  }
+
+  property("JVM InternalError is not misclassified as a stack overflow") {
+    SigmaCompiler.isStackOverflow(new InternalError("broken VM"), isJVM = true) shouldBe false
+  }
+
+  property("JVM UnknownError is not misclassified as a stack overflow") {
+    SigmaCompiler.isStackOverflow(new UnknownError("unknown VM error"), isJVM = true) shouldBe false
+  }
+
+  property("JS JavaScriptException wrapping a stack RangeError is detected") {
+    SigmaCompiler.isStackOverflow(
+      new JavaScriptException("RangeError: Maximum call stack size exceeded"),
+      isJVM = false) shouldBe true
+  }
+
+  property("JS JavaScriptException wrapping Firefox recursion message is detected") {
+    SigmaCompiler.isStackOverflow(
+      new JavaScriptException("InternalError: too much recursion"),
+      isJVM = false) shouldBe true
+  }
+
+  property("JS JavaScriptException wrapping a non-stack RangeError is not misclassified") {
+    SigmaCompiler.isStackOverflow(
+      new JavaScriptException("RangeError: Invalid array length"),
+      isJVM = false) shouldBe false
+  }
+}

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -9,7 +9,8 @@ import sigmastate._
 import sigmastate.helpers.CompilerTestingCommons
 import sigmastate.interpreter.Interpreter.ScriptEnv
 import sigma.ast.{Apply, MethodCall, ZKProofBlock}
-import sigma.exceptions.{GraphBuildingException, InvalidArguments, TyperException}
+import sigma.compiler.SigmaCompiler
+import sigma.exceptions.{CompilerException, GraphBuildingException, InvalidArguments, TyperException}
 import sigma.serialization.ValueSerializer
 import sigma.serialization.generators.ObjectGenerators
 
@@ -345,5 +346,19 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
         GetVarIntArray(2).get,
         GetVar(3.toByte, SCollection(SSigmaProp)).get
       )
+  }
+
+  property("stack overflow during typecheck is wrapped into CompilerException") {
+    // Regression test for a StackOverflowError in the binder's reduce/rewriting loop
+    // (see SrcCtxCallbackRewriter / SigmaBinder.eval). A recursive environment binding,
+    // where a name resolves to an Ident of the same name, makes the binder's reduce
+    // strategy loop forever and overflow the stack. SigmaCompiler.typecheck must catch
+    // the StackOverflowError and rethrow it as a checked CompilerException instead of
+    // letting it escalate to a fatal JVM error.
+    val compiler = SigmaCompiler(TestnetNetworkPrefix)
+    val recursiveEnv: ScriptEnv = Map("x" -> Ident("x", NoType))
+    val parsed = compiler.parse("x")
+    val e = the[CompilerException] thrownBy compiler.typecheck(recursiveEnv, parsed)
+    e.getMessage should include("too complex or recursive")
   }
 }

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -354,11 +354,25 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     // where a name resolves to an Ident of the same name, makes the binder's reduce
     // strategy loop forever and overflow the stack. SigmaCompiler.typecheck must catch
     // the StackOverflowError and rethrow it as a checked CompilerException instead of
-    // letting it escalate to a fatal JVM error.
+    // letting it escalate to a fatal runtime error.
     val compiler = SigmaCompiler(TestnetNetworkPrefix)
     val recursiveEnv: ScriptEnv = Map("x" -> Ident("x", NoType))
     val parsed = compiler.parse("x")
     val e = the[CompilerException] thrownBy compiler.typecheck(recursiveEnv, parsed)
     e.getMessage should include("too complex or recursive")
+    e.getCause should not be null
+  }
+
+  property("compiler is still usable after a stack overflow is caught") {
+    // Ensure that catching a stack overflow does not corrupt the compiler/builder state
+    // so that subsequent compilations on the same instance succeed.
+    val compiler = SigmaCompiler(TestnetNetworkPrefix)
+    val recursiveEnv: ScriptEnv = Map("x" -> Ident("x", NoType))
+    val parsed = compiler.parse("x")
+    the[CompilerException] thrownBy compiler.typecheck(recursiveEnv, parsed)
+
+    // Reuse the same compiler for a normal expression.
+    compiler.typecheck(Map.empty, compiler.parse("1 + 2")) shouldBe
+      Plus(IntConstant(1), IntConstant(2))
   }
 }

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -372,7 +372,7 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     the[CompilerException] thrownBy compiler.typecheck(recursiveEnv, parsed)
 
     // Reuse the same compiler for a normal expression.
-    compiler.typecheck(Map.empty, compiler.parse("1 + 2")) shouldBe
+    compiler.typecheck(Map.empty[String, Any], compiler.parse("1 + 2")) shouldBe
       Plus(IntConstant(1), IntConstant(2))
   }
 }


### PR DESCRIPTION
In this PR, during typecheck, StackOverflowError (and other non-OOM VirtualMachineErrors) is wrapped into a checked CompilerException so that a malformed/pathological script results in a normal compilation error instead of a fatal JVM error.