### PR TITLE
Clean up sbt deprecation warnings in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val commonSettings = Seq(
     }
   },
   javacOptions ++= javacReleaseOption,
-  resolvers ++= Resolver.sonatypeOssRepos("releases"),
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),
   homepage := Some(url("https://github.com/ergoplatform/sigmastate-interpreter")),
   description := "Interpreter of a Sigma-State language",

--- a/build.sbt
+++ b/build.sbt
@@ -147,16 +147,16 @@ lazy val testSettings = Seq(
   Test / parallelExecution := false,
   Test / baseDirectory := file("."),
   Test / publishArtifact := true,
-  publishArtifact in(Test, packageSrc) := true,
-  publishArtifact in(Test, packageDoc) := false,
+  Test / packageSrc / publishArtifact := true,
+  Test / packageDoc / publishArtifact := false,
   assembly / test := {})
 
 lazy val testSettings2 = Seq(
   Test / parallelExecution := true,
   Test / baseDirectory := file("."),
   Test / publishArtifact := true,
-  publishArtifact in(Test, packageSrc) := true,
-  publishArtifact in(Test, packageDoc) := false,
+  Test / packageSrc / publishArtifact := true,
+  Test / packageDoc / publishArtifact := false,
   assembly / test := {})
 
 scalacOptions ++= Seq("-feature", "-deprecation")
@@ -377,9 +377,9 @@ lazy val rootSettings = Seq(
   Compile / sources := sources.all(aggregateCompile).value.flatten,
   Compile / sourceDirectories := sourceDirectories.all(aggregateCompile).value.flatten,
   libraryDependencies := libraryDependencies.all(aggregateCompile).value.flatten,
-  mappings in (Compile, packageSrc) ++= (mappings in(Compile, packageSrc)).all(aggregateCompile).value.flatten,
-  mappings in (Test, packageBin) ++= (mappings in(Test, packageBin)).all(aggregateCompile).value.flatten,
-  mappings in(Test, packageSrc) ++= (mappings in(Test, packageSrc)).all(aggregateCompile).value.flatten
+  Compile / packageSrc / mappings ++= (Compile / packageSrc / mappings).all(aggregateCompile).value.flatten,
+  Test / packageBin / mappings ++= (Test / packageBin / mappings).all(aggregateCompile).value.flatten,
+  Test / packageSrc / mappings ++= (Test / packageSrc / mappings).all(aggregateCompile).value.flatten
 )
 
 val credentialFile = Path.userHome / ".sbt" / ".sigma-sonatype-credentials"


### PR DESCRIPTION
- Migrate deprecated `in(...)` scopings to slash syntax.
- Remove the sunset OSSRH `releases` resolver (redundant with Maven Central; no SNAPSHOT deps in the build).

Build loads with zero deprecation warnings; `sbt update` succeeds.