### PR TITLE
Add frontend-only stripErgoTreeHeader helper

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -276,6 +276,21 @@ object SigmaPredef {
           Seq(ArgInfo("input", "collection of bytes")))
     )
 
+    // Frontend-only expansion: reuse existing nodes, serialization and evaluation costs.
+    val StripErgoTreeHeaderFunc = PredefinedFunc("stripErgoTreeHeader",
+      Lambda(Array("treeBytes" -> SByteArray), SByteArray, None),
+      PredefFuncInfo(
+        { case (_, Seq(arg: Value[SByteArray]@unchecked)) =>
+          mkSlice(arg, IntConstant(1), mkSizeOf(arg))
+        }),
+      OperationInfo(None,
+        """Skips exactly the first byte of serialized ErgoTree bytes.
+          |Equivalent to treeBytes.slice(1, treeBytes.size); empty or one-byte inputs return an empty collection.
+          |Does not validate the input or normalize size fields, segregated constants or serialization formats.
+        """.stripMargin,
+        Seq(ArgInfo("treeBytes", "serialized ErgoTree bytes")))
+    )
+
     val ByteArrayToBigIntFunc = PredefinedFunc("byteArrayToBigInt",
       Lambda(Array("input" -> SByteArray), SBigInt, None),
       PredefFuncInfo(
@@ -548,6 +563,7 @@ object SigmaPredef {
       FromBase58Func,
       Blake2b256Func,
       Sha256Func,
+      StripErgoTreeHeaderFunc,
       ByteArrayToBigIntFunc,
       ByteArrayToLongFunc,
       DecodePointFunc,

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -1118,6 +1118,12 @@ def blake2b256(input: Coll[Byte]): Coll[Byte]
 /** Cryptographic hash function Sha256 (See scorex.crypto.hash.Sha256) */
 def sha256(input: Coll[Byte]): Coll[Byte]
 
+/** Skips the first header byte of serialized ErgoTree bytes.
+  * Equivalent to treeBytes.slice(1, treeBytes.size).
+  * Empty and one-byte inputs produce an empty collection.
+  */
+def stripErgoTreeHeader(treeBytes: Coll[Byte]): Coll[Byte]
+
 /** Create an instance of type T from bytes of its wrapped type. 
 See https://github.com/ScorexFoundation/sigmastate-interpreter/pull/979 for more details */
 def deserializeTo[T](input: Coll[Byte]): T
@@ -1332,6 +1338,19 @@ def executeFromSelfRegWithDefault[T](id: Int, default: T): T
   */
 def substConstants[T](scriptBytes: Coll[Byte], positions: Coll[Int], newValues: Coll[T]): Coll[Byte]
 ```
+
+To compare or hash serialized ErgoTrees while ignoring their first header byte:
+
+```scala
+val receiptTreeHash = blake2b256(stripErgoTreeHeader(OUTPUTS(0).propositionBytes))
+```
+
+`stripErgoTreeHeader` preserves every byte after the first byte. It does not
+validate or deserialize the input, remove an optional size field or segregated
+constants, or normalize different serialization formats. Equality of the result
+therefore means byte equality after the first byte, not semantic equivalence of
+the contracts. The compiler expands the helper to the existing collection slice
+operation; it does not introduce a new ErgoTree opcode.
 
 ## Known Limitations
 

--- a/sc/shared/src/test/scala/sigmastate/ErgoTreeHeaderSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/ErgoTreeHeaderSpecification.scala
@@ -1,0 +1,108 @@
+package sigmastate
+
+import scorex.crypto.hash.Blake2b256
+import sigma.ast._
+import sigma.ast.syntax._
+import sigma.data.TrivialProp
+import sigma.exceptions.TyperException
+import sigma.interpreter.ContextExtension
+import sigma.serialization.{ErgoTreeSerializer, ValueSerializer}
+import sigmastate.helpers.{CompilerTestingCommons, ErgoLikeContextTesting, ErgoLikeTestInterpreter}
+import sigmastate.helpers.TestingHelpers.createBox
+import sigmastate.interpreter.Interpreter
+import sigmastate.interpreter.Interpreter.ReductionResult
+
+class ErgoTreeHeaderSpecification extends CompilerTestingCommons with CompilerCrossVersionProps {
+  implicit lazy val IR: TestingIRContext = new TestingIRContext
+  private lazy val interpreter = new ErgoLikeTestInterpreter
+
+  private def expression(code: String): SValue = compile(Interpreter.emptyEnv, code)
+
+  private def contract(condition: String): ErgoTree = {
+    val tree = mkTestErgoTree(expression(s"sigmaProp($condition)").asSigmaProp)
+    val restored = ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(tree.bytes)
+    restored shouldBe tree
+    restored
+  }
+
+  private def reduce(tree: ErgoTree, values: Array[Byte]*): ReductionResult = {
+    val bindings = values.zipWithIndex.map { case (bytes, index) =>
+      (index + 1).toByte -> ByteArrayConstant(bytes)
+    }.toMap
+    val ctx = ErgoLikeContextTesting.dummy(createBox(0, TrueTree), activatedVersionInTests)
+      .withExtension(ContextExtension(bindings))
+      .withErgoTreeVersion(ergoTreeVersionInTests)
+    interpreter.fullReduction(tree, ctx)
+  }
+
+  property("stripErgoTreeHeader lowers to the existing slice and preserves serialized bytes") {
+    val inputs = Seq(
+      "getVar[Coll[Byte]](1).get",
+      "SELF.propositionBytes",
+      "blake2b256(getVar[Coll[Byte]](1).get)")
+    inputs.foreach { input =>
+      val helper = expression(s"stripErgoTreeHeader($input)")
+      val explicit = expression(s"{ val bytes = $input; bytes.slice(1, bytes.size) }")
+      helper shouldBe explicit
+      ValueSerializer.serialize(helper) shouldEqual ValueSerializer.serialize(explicit)
+      ValueSerializer.deserialize(ValueSerializer.serialize(helper)) shouldBe helper
+    }
+  }
+
+  property("stripErgoTreeHeader removes exactly one byte from runtime collections") {
+    val tree = contract("stripErgoTreeHeader(getVar[Coll[Byte]](1).get) == getVar[Coll[Byte]](2).get")
+    val cases = Seq(
+      Array.emptyByteArray -> Array.emptyByteArray,
+      Array[Byte](0) -> Array.emptyByteArray,
+      Array[Byte](16, 1, 2, 3) -> Array[Byte](1, 2, 3),
+      Array[Byte](-1, -128, 0, 127) -> Array[Byte](-128, 0, 127),
+      // A size field or constant section after the first byte is not normalized away.
+      Array[Byte](8, 2, 1, 2) -> Array[Byte](2, 1, 2))
+    cases.foreach { case (input, expected) =>
+      reduce(tree, input, expected).value shouldBe TrivialProp.TrueProp
+    }
+    reduce(tree, Array[Byte](0, 1, 2), Array[Byte](0, 1, 2)).value shouldBe TrivialProp.FalseProp
+  }
+
+  property("stripErgoTreeHeader comparisons ignore only the first byte") {
+    val tree = contract(
+      "stripErgoTreeHeader(getVar[Coll[Byte]](1).get) == stripErgoTreeHeader(getVar[Coll[Byte]](2).get)")
+    reduce(tree, Array[Byte](0, 1, 2), Array[Byte](16, 1, 2)).value shouldBe TrivialProp.TrueProp
+    reduce(tree, Array[Byte](0, 1, 2), Array[Byte](0, 1, 3)).value shouldBe TrivialProp.FalseProp
+    reduce(tree, Array[Byte](0, 1, 2), Array[Byte](0, 1)).value shouldBe TrivialProp.FalseProp
+  }
+
+  property("stripErgoTreeHeader supports the runtime receipt hash use case") {
+    val tree = contract(
+      "blake2b256(stripErgoTreeHeader(getVar[Coll[Byte]](1).get)) == getVar[Coll[Byte]](2).get")
+    val expectedHash = Blake2b256.hash(Array[Byte](1, 2, 3))
+    reduce(tree, Array[Byte](0, 1, 2, 3), expectedHash).value shouldBe TrivialProp.TrueProp
+    reduce(tree, Array[Byte](16, 1, 2, 3), expectedHash).value shouldBe TrivialProp.TrueProp
+    reduce(tree, Array[Byte](0, 1, 2, 4), expectedHash).value shouldBe TrivialProp.FalseProp
+    reduce(tree, Array[Byte](0), Blake2b256.hash(Array.emptyByteArray)).value shouldBe TrivialProp.TrueProp
+  }
+
+  property("stripErgoTreeHeader shares a computed argument like an explicit slice") {
+    val helper = contract(
+      "stripErgoTreeHeader(blake2b256(getVar[Coll[Byte]](1).get)) == getVar[Coll[Byte]](2).get")
+    val explicit = contract(
+      "{ val bytes = blake2b256(getVar[Coll[Byte]](1).get); bytes.slice(1, bytes.size) == getVar[Coll[Byte]](2).get }")
+    helper.bytes shouldEqual explicit.bytes
+    val input = Array[Byte](1, 2, 3)
+    val expected = Blake2b256.hash(input).drop(1)
+    val actual = reduce(helper, input, expected)
+    actual.value shouldBe TrivialProp.TrueProp
+    actual shouldBe reduce(explicit, input, expected)
+  }
+
+  property("stripErgoTreeHeader rejects incorrect argument types and arity") {
+    Seq(
+      "stripErgoTreeHeader()",
+      "stripErgoTreeHeader(1)",
+      "stripErgoTreeHeader(Coll(1, 2))",
+      "stripErgoTreeHeader(Coll[Byte](), Coll[Byte]())"
+    ).foreach { code =>
+      an[TyperException] should be thrownBy expression(code)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1075.

The issue asks for an ErgoScript function that replaces `treeBytes.slice(1, treeBytes.size)`. This adds `stripErgoTreeHeader(treeBytes: Coll[Byte]): Coll[Byte]` to the predefined compiler functions, so the receipt-hash example becomes:

```scala
val receiptTreeHash = blake2b256(stripErgoTreeHeader(OUTPUTS(0).propositionBytes))
```

The helper expands to existing `Slice`/`SizeOf` nodes. No interpreter code, opcode, or serialization format changes. It removes exactly one byte, including for runtime collections; empty and one-byte inputs return an empty collection. The documentation explicitly excludes normalization of size fields, segregated constants, or semantically equivalent contracts.

Validation on Scala 2.13.18 / Java 17:

```text
sbt 'scJVM/testOnly sigmastate.ErgoTreeHeaderSpecification sigmastate.lang.SigmaCompilerTest sigmastate.utils.SpecGenGoldenSpec'
59 tests passed; 0 failed.
```

The new suite executes compiled calls with runtime context variables, covers header/body differences and the receipt hash, checks ErgoTree and ValueSerializer round-trips, and compares compiled bytes and evaluation cost against an explicit slice with a shared computed argument. The spec-generation golden tests also pass. Before the implementation, five of the six new tests failed because the helper was absent. The full repository test suite has not been run.

This is a focused compiler-only alternative to the existing #1100/#1101 submissions. Please consider it for the advertised 200 SigUSD bounty; I have not assumed a reservation or award, and understand that eligibility and payment depend on maintainer acceptance.

Implementation and verification assisted by OpenAI Codex.